### PR TITLE
Fix incorrect memory access in projectBatch

### DIFF
--- a/okvis_cv/include/okvis/cameras/implementation/PinholeCamera.hpp
+++ b/okvis_cv/include/okvis/cameras/implementation/PinholeCamera.hpp
@@ -631,7 +631,6 @@ bool PinholeCamera<DISTORTION_T>::backProjectBatch(
     std::vector<bool> * success) const
 {
   const int numPoints = imagePoints.cols();
-  directions->row(3) = Eigen::VectorXd::Ones(numPoints);
   for (int i = 0; i < numPoints; ++i) {
     Eigen::Vector2d imagePoint = imagePoints.col(i);
     Eigen::Vector3d point;


### PR DESCRIPTION
The code was performing an incorrect memory access by using a .row(3) function call of an Eigen::Matrix3Xf. This row is not available in Matrix3Xf, since maximum row index is 2. The code is correct without this line (which was setting everything to 1s), so by deleting this line we fix it.