### PR TITLE
Fix incorrect memory access

### DIFF
--- a/okvis_frontend/src/Frontend.cpp
+++ b/okvis_frontend/src/Frontend.cpp
@@ -329,6 +329,9 @@ bool Frontend::verifyRecognisedPlace(const Estimator &estimator,
   // match
   for (auto iter = landmarks.begin(); iter != landmarks.end(); ++iter) {
     for (size_t im = 0; im < params.nCameraSystem.numCameras(); ++im) {
+       if(framesInOut->numKeypoints(im) == 0) {
+        continue;
+      }
       const uchar *ddata = framesInOut->keypointDescriptor(im, 0);
       const size_t K = framesInOut->numKeypoints(im);
       uint32_t distMin = briskMatchingThreshold_;


### PR DESCRIPTION
In the function verifyRecognisedPlace there was a function to access the first keypoint of an image, although there was no prior check on whether or not keypoints had been allocated, leading to a potentially risky memory access. Added a check to see if keypoints have been allocated or not.