### PR TITLE
Added conditional inclusion of cv_bridge for ROS2 humble

### DIFF
--- a/okvis_ros2/include/okvis/ros2/RePublisher.hpp
+++ b/okvis_ros2/include/okvis/ros2/RePublisher.hpp
@@ -44,7 +44,11 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
 #include <opencv2/core/core.hpp>
+#if __has_include(<cv_bridge/cv_bridge.hpp>) // requires GCC >= 5
 #include <cv_bridge/cv_bridge.hpp>
+#else
+#include <cv_bridge/cv_bridge.h>
+#endif
 #include <image_transport/image_transport.hpp>
 #pragma GCC diagnostic pop
 #include <rclcpp/rclcpp.hpp>

--- a/okvis_ros2/include/okvis/ros2/Subscriber.hpp
+++ b/okvis_ros2/include/okvis/ros2/Subscriber.hpp
@@ -46,7 +46,11 @@
 #include <boost/shared_ptr.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <image_transport/image_transport.hpp>
+#if __has_include(<cv_bridge/cv_bridge.hpp>) // requires GCC >= 5
 #include <cv_bridge/cv_bridge.hpp>
+#else
+#include <cv_bridge/cv_bridge.h>
+#endif
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 #pragma GCC diagnostic push

--- a/okvis_ros2/src/RosbagReader.cpp
+++ b/okvis_ros2/src/RosbagReader.cpp
@@ -47,7 +47,11 @@
 #include <rosbag2_cpp/converter_interfaces/serialization_format_converter.hpp>
 #include <rosbag2_storage/storage_options.hpp>
 #include <image_transport/image_transport.hpp>
+#if __has_include(<cv_bridge/cv_bridge.hpp>) // requires GCC >= 5
 #include <cv_bridge/cv_bridge.hpp>
+#else
+#include <cv_bridge/cv_bridge.h>
+#endif
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 #include <rosbag2_storage/storage_options.hpp>


### PR DESCRIPTION
The default CV_bridge pkg in ROS2 humble is still using `#include <cv_bridge/cv_bridge.h>` instead of `.hpp`. 