### PR TITLE
imu preintegration refactor and bug fixes

### DIFF
--- a/okvis_ceres/include/okvis/ceres/ImuError.hpp
+++ b/okvis_ceres/include/okvis/ceres/ImuError.hpp
@@ -77,20 +77,20 @@ class ImuErrorBase : public ::ceres::SizedCostFunction<
   static const int kNumResiduals = 15;
 
   /// \brief The type of the covariance.
-  typedef Eigen::Matrix<double, 15, 15> covariance_t;
+  typedef Eigen::Matrix<double, kNumResiduals, kNumResiduals> covariance_t;
 
   /// \brief The type of the information (same matrix dimension as covariance).
   typedef covariance_t information_t;
 
   /// \brief The type of hte overall Jacobian.
-  typedef Eigen::Matrix<double, 15, 15> jacobian_t;
+  typedef Eigen::Matrix<double, kNumResiduals, kNumResiduals> jacobian_t;
 
   /// \brief The type of the Jacobian w.r.t. poses --
   /// \warning This is w.r.t. minimal tangential space coordinates...
-  typedef Eigen::Matrix<double, 15, 7> jacobian0_t;
+  typedef Eigen::Matrix<double, kNumResiduals, 7> jacobian0_t;
 
   /// \brief The type of Jacobian w.r.t. Speed and biases
-  typedef Eigen::Matrix<double, 15, 9> jacobian1_t;
+  typedef Eigen::Matrix<double, kNumResiduals, 9> jacobian1_t;
 
   /// \brief Trivial destructor.
   virtual ~ImuErrorBase() override = default;
@@ -284,6 +284,98 @@ class ImuError :
   }
 
  protected:
+
+  struct PreintegratedMeasurements
+  {
+    Eigen::Quaterniond Delta_q;
+    Eigen::Vector3d Delta_v;
+    Eigen::Vector3d Delta_p;
+
+    PreintegratedMeasurements operator*(const PreintegratedMeasurements & other) const
+    {
+      PreintegratedMeasurements result;
+      result.Delta_q = Delta_q * other.Delta_q;
+      result.Delta_p = Delta_p + other.Delta_p;
+      result.Delta_v = Delta_v + other.Delta_v;
+      return result;
+    }
+
+    static PreintegratedMeasurements Identity()
+    {
+      PreintegratedMeasurements id;
+      id.Delta_q = Eigen::Quaterniond(1, 0, 0, 0);
+      id.Delta_v = Eigen::Vector3d::Zero();
+      id.Delta_p = Eigen::Vector3d::Zero();
+      return id;
+    }
+  };
+
+  struct HelperMeasurements
+  {
+    Eigen::Matrix3d C_integral;
+    Eigen::Matrix3d C_doubleintegral;
+    Eigen::Matrix3d dq_db_g;
+    Eigen::Matrix3d dalpha_db_g;
+    Eigen::Matrix3d dv_db_g;
+    Eigen::Matrix3d dp_db_g;
+    Eigen::Matrix3d ddv_db_g;
+
+    static HelperMeasurements Zero()
+    {
+      HelperMeasurements h;
+      h.C_integral = Eigen::Matrix3d::Zero();
+      h.C_doubleintegral = Eigen::Matrix3d::Zero();
+      h.dq_db_g = Eigen::Matrix3d::Zero();
+      h.dalpha_db_g = Eigen::Matrix3d::Zero();
+      h.dv_db_g = Eigen::Matrix3d::Zero();
+      h.dp_db_g = Eigen::Matrix3d::Zero();
+      h.ddv_db_g = Eigen::Matrix3d::Zero();
+      return h;
+    }
+  };
+
+  /**
+   * @brief Reset preintegrated measurements to identity, helper measurements to zero and preintegration covariance to zero.
+   */
+  void reset() const;
+
+  /**
+   * @brief Compute preintegrated measurement Delta_x_ik+1 from given measurement and time delta.
+   * @param[in] imu The imu measurement at time k.
+   * @param[in] dt Time delta tk+1 - tk.
+   * @return The preintegrated measurement.
+   */
+  static PreintegratedMeasurements computePreintegratedIncrements(
+    const PreintegratedMeasurements & preintegrated, const ImuSensorReadings & imu, double dt);
+
+  /**
+   * @brief Compute helper measurement at time k up to time k+1.
+   * @param[in] imu The imu measurement at time k.
+   * @param[in] dt Time delta tk+1 - tk.
+   * @param[in] C_0 Preintegrated rotation at time k Delta_R_ik.
+   * @param[in] C_1 Preintegrated rotation at time k+1 Delta_R_ik+1.
+   * @param[in] dq Preintegrated rotation increment at time k.
+   * @return The helper measurement increments.
+   */
+  static HelperMeasurements computeNextHelperMeasurements(
+    const HelperMeasurements & helpers, const ImuSensorReadings & imu, double dt,
+    const Eigen::Matrix3d & C_0, const Eigen::Matrix3d & C_1, const Eigen::Quaterniond & dq);
+
+  /**
+   * @brief Do propagation from t0_ to t1_ with given start states.
+   * @param[in] speedAndBiases Start speed and biases.
+   * @param[in] imuMeasurements The IMU measurements to be used. Must span t0_ - t1_.
+   * @param[in] t0 Start time.
+   * @param[in] t1 End time.
+   * @param[in] reset If true, reset preintegrated measurements, helpers and covariance.
+   * @return Number of integration steps.
+   */
+  static int doPropagation(
+    PreintegratedMeasurements & preintegrated, HelperMeasurements & helpers,
+    Eigen::Matrix<double, kNumResiduals, kNumResiduals> & covariance,
+    const ImuParameters & imu_parameters, const ImuMeasurementDeque & imuMeasurements,
+    const SpeedAndBias & speedAndBiases, const Time & t0, const Time & t1);
+
   // parameters
   okvis::ImuParameters imuParameters_; ///< The IMU parameters.
 
@@ -292,23 +384,16 @@ class ImuError :
 
   // preintegration stuff. the mutable is a TERRIBLE HACK, but what can I do.
   mutable std::mutex preintegrationMutex_; ///< Protect access of intermediate results.
-  // increments (initialise with identity)
-  mutable Eigen::Quaterniond Delta_q_ = Eigen::Quaterniond(1,0,0,0); ///< Intermediate result
-  mutable Eigen::Matrix3d C_integral_ = Eigen::Matrix3d::Zero(); ///< Intermediate result
-  mutable Eigen::Matrix3d C_doubleintegral_ = Eigen::Matrix3d::Zero(); ///< Intermediate result
-  mutable Eigen::Vector3d acc_integral_ = Eigen::Vector3d::Zero(); ///< Intermediate result
-  mutable Eigen::Vector3d acc_doubleintegral_ = Eigen::Vector3d::Zero(); ///< Intermediate result
 
-  // cross matrix accumulatrion
-  mutable Eigen::Matrix3d cross_ = Eigen::Matrix3d::Zero(); ///< Intermediate result
-
-  // sub-Jacobians
-  mutable Eigen::Matrix3d dalpha_db_g_ = Eigen::Matrix3d::Zero(); ///< Intermediate result
-  mutable Eigen::Matrix3d dv_db_g_ = Eigen::Matrix3d::Zero(); ///< Intermediate result
-  mutable Eigen::Matrix3d dp_db_g_ = Eigen::Matrix3d::Zero(); ///< Intermediate result
+  /// \brief The preintegrated measurements.
+  mutable PreintegratedMeasurements preintegrated_;
+  
+  /// \brief Helper variables for the preintegration.
+  mutable HelperMeasurements helpers_;
 
   /// \brief The Jacobian of the increment (w/o biases).
-  mutable Eigen::Matrix<double,15,15> P_delta_ = Eigen::Matrix<double,15,15>::Zero();
+  mutable Eigen::Matrix<double, kNumResiduals, kNumResiduals> P_delta_
+  ;
 
   /// \brief Reference biases that are updated when called redoPreintegration.
   mutable SpeedAndBias speedAndBiases_ref_ = SpeedAndBias::Zero();
@@ -321,7 +406,7 @@ class ImuError :
   mutable information_t squareRootInformation_; ///< The square root information of this error term.
 
   /// \brief For gradient/hessian w.r.t. the sigmas.
-  mutable AlignedVector<Eigen::Matrix<double,15,15>> dPdsigma_;
+  mutable AlignedVector<Eigen::Matrix<double, kNumResiduals, kNumResiduals>> dPdsigma_;
 
 };
 

--- a/okvis_ceres/include/okvis/ceres/ImuError.hpp
+++ b/okvis_ceres/include/okvis/ceres/ImuError.hpp
@@ -168,9 +168,7 @@ class ImuError :
   /// \brief Append with measurements and parameters.
   /// \@param[in] imuMeasurements All the IMU measurements.
   /// \@param[in] t_1 End time.
-  int append(const okvis::kinematics::Transformation& T_WS,
-             const okvis::SpeedAndBias & speedAndBiases,
-             const okvis::ImuMeasurementDeque & imuMeasurements,
+  int append(const okvis::ImuMeasurementDeque & imuMeasurements,
              const okvis::Time& t_1);
 
   /**
@@ -334,6 +332,33 @@ class ImuError :
     }
   };
 
+  /// \brief One integration interval, aligned to the preintegration period and bias-corrected.
+  struct AlignedInterval
+  {
+    double dt;              ///< Interval duration [s].
+    ImuSensorReadings imu;  ///< Midpoint reading over the interval, with the biases removed.
+    double sigma_g_c;       ///< Gyroscope noise density, scaled up on saturation.
+    double sigma_a_c;       ///< Accelerometer noise density, scaled up on saturation.
+  };
+
+  /**
+   * @brief Align measurements to the given time interval and correct them for the given biases.
+   *
+   * Interpolates so that the first and last interval coincide exactly with t0 and t1, drops the
+   * intervals outside [t0, t1], and reduces each remaining interval to its midpoint reading with
+   * the biases removed.
+   *
+   * @param[in] imuMeasurements The IMU measurements. Must span t0 - t1.
+   * @param[in] imuParameters The parameters to be used.
+   * @param[in] speedAndBiases Speed and biases providing the biases to remove.
+   * @param[in] t0 Start time.
+   * @param[in] t1 End time.
+   * @return One entry per integration interval, in chronological order.
+   */
+  static std::vector<AlignedInterval> alignAndCorrectMeasurements(
+    const ImuMeasurementDeque & imuMeasurements, const ImuParameters & imuParameters,
+    const SpeedAndBias & speedAndBiases, const Time & t0, const Time & t1);
+
   /**
    * @brief Reset preintegrated measurements to identity, helper measurements to zero and preintegration covariance to zero.
    */
@@ -362,19 +387,18 @@ class ImuError :
     const Eigen::Matrix3d & C_0, const Eigen::Matrix3d & C_1, const Eigen::Quaterniond & dq);
 
   /**
-   * @brief Do propagation from t0_ to t1_ with given start states.
-   * @param[in] speedAndBiases Start speed and biases.
-   * @param[in] imuMeasurements The IMU measurements to be used. Must span t0_ - t1_.
-   * @param[in] t0 Start time.
-   * @param[in] t1 End time.
-   * @param[in] reset If true, reset preintegrated measurements, helpers and covariance.
+   * @brief Propagate the preintegrated measurements over already-aligned intervals.
+   * @param[inout] preintegrated The preintegrated measurements to advance.
+   * @param[inout] helpers The helper variables to advance.
+   * @param[inout] covariance The preintegration covariance to advance.
+   * @param[in] imu_parameters The parameters to be used, for the bias random walk noise densities.
+   * @param[in] intervals The intervals as returned by alignAndCorrectMeasurements().
    * @return Number of integration steps.
    */
   static int doPropagation(
     PreintegratedMeasurements & preintegrated, HelperMeasurements & helpers,
     Eigen::Matrix<double, kNumResiduals, kNumResiduals> & covariance,
-    const ImuParameters & imu_parameters, const ImuMeasurementDeque & imuMeasurements,
-    const SpeedAndBias & speedAndBiases, const Time & t0, const Time & t1);
+    const ImuParameters & imu_parameters, const std::vector<AlignedInterval> & intervals);
 
   // parameters
   okvis::ImuParameters imuParameters_; ///< The IMU parameters.
@@ -398,7 +422,6 @@ class ImuError :
   /// \brief Reference biases that are updated when called redoPreintegration.
   mutable SpeedAndBias speedAndBiases_ref_ = SpeedAndBias::Zero();
 
-  mutable bool redo_ = true; ///< Keeps track of whether or not redoPreintegration() is needed.
   mutable int redoCounter_ = 0; ///< Counts the number of preintegrations for statistics.
 
   // information matrix and its square root

--- a/okvis_ceres/src/ImuError.cpp
+++ b/okvis_ceres/src/ImuError.cpp
@@ -59,454 +59,36 @@ std::atomic_bool ImuError::redoPropagationAlways(false);
 ImuError::ImuError(const okvis::ImuMeasurementDeque & imuMeasurements,
                    const okvis::ImuParameters & imuParameters,
                    const okvis::Time& t_0, const okvis::Time& t_1) {
+  
+  reset();
+
   setImuMeasurements(imuMeasurements);
   setImuParameters(imuParameters);
+
   setT0(t_0);
   setT1(t_1);
 
-  OKVIS_ASSERT_TRUE_DBG(Exception,
-                     t_0 >= imuMeasurements.front().timeStamp,
-                     "First IMU measurement included in ImuError is not old enough! "
-                        << t_0 << " !>= " << imuMeasurements.front().timeStamp)
-  OKVIS_ASSERT_TRUE_DBG(Exception,
-                     t_1 <= imuMeasurements.back().timeStamp,
-                     "Last IMU measurement included in ImuError is not new enough!"
-                         << t_1 << " !<= " << imuMeasurements.back().timeStamp)
+  OKVIS_ASSERT_TRUE_DBG(
+    Exception, t_0 >= imuMeasurements.front().timeStamp,
+    "First IMU measurement included in ImuError is not old enough! "
+      << t_0 << " !>= " << imuMeasurements.front().timeStamp)
+  OKVIS_ASSERT_TRUE_DBG(
+    Exception, t_1 <= imuMeasurements.back().timeStamp,
+    "Last IMU measurement included in ImuError is not new enough!"
+      << t_1 << " !<= " << imuMeasurements.back().timeStamp)
+}
 
-  // derivatives of covariance matrix w.r.t. sigmas
+void ImuError::reset() const
+{
+  preintegrated_ = PreintegratedMeasurements::Identity();
+  helpers_ = HelperMeasurements::Zero();
+
+  P_delta_ = Eigen::MatrixXd::Zero(kNumResiduals, kNumResiduals);
+
   dPdsigma_.resize(4);
-  for(size_t j=0; j<4; ++j) {
+  for (size_t j = 0; j < 4; ++j) {
     dPdsigma_.at(j).setZero();
   }
-}
-
-int ImuError::append(const okvis::kinematics::Transformation& /*T_WS*/,
-                     const okvis::SpeedAndBias & speedAndBiases,
-                     const okvis::ImuMeasurementDeque & imuMeasurements, const okvis::Time& t_1)
-{
-  // sanity check for time overlap and end time consistency
-  OKVIS_ASSERT_TRUE_DBG(Exception, t1_ >= imuMeasurements.front().timeStamp,
-                        "First IMU measurement included in ImuError is not old enough!")
-  OKVIS_ASSERT_TRUE_DBG(Exception, t_1 <= imuMeasurements.back().timeStamp,
-                        "Last IMU measurement included in ImuError is not new enough!")
-
-  // merge IMU deque
-  okvis::ImuMeasurementDeque::const_iterator iter = imuMeasurements.begin();
-  while (iter != imuMeasurements.end()){
-    if (iter->timeStamp > imuMeasurements_.back().timeStamp) {
-      break;
-    }
-    ++iter;
-  }
-  imuMeasurements_.insert(imuMeasurements_.end(),iter,imuMeasurements.end());
-
-  // adapted redoPropagation
-  okvis::Time time = t1_;
-  okvis::Time end = t_1;
-  setT1(t_1);
-
-  // sanity check:
-  assert(imuMeasurements.front().timeStamp<=time);
-  if (!(imuMeasurements.back().timeStamp >= end))
-    return -1;  // nothing to do...
-
-  // increments, cross matrix accumulation, sub-Jacobians,
-  // the Jacobian of the increment (w/o biases): all left, not reset!
-
-  bool hasStarted = false;
-  int i = 0;
-  for (okvis::ImuMeasurementDeque::const_iterator it = imuMeasurements.begin();
-      it != imuMeasurements.end(); ++it) {
-
-    Eigen::Vector3d omega_S_0 = it->measurement.gyroscopes;
-    Eigen::Vector3d acc_S_0 = it->measurement.accelerometers;
-    Eigen::Vector3d omega_S_1 = (it + 1)->measurement.gyroscopes;
-    Eigen::Vector3d acc_S_1 = (it + 1)->measurement.accelerometers;
-
-    // time delta
-    okvis::Time nexttime;
-    if ((it + 1) == imuMeasurements_.end()) {
-      nexttime = t1_;
-    } else
-      nexttime = (it + 1)->timeStamp;
-    double dt = (nexttime - time).toSec();
-
-    if (end < nexttime) {
-      double interval = (nexttime - it->timeStamp).toSec();
-      nexttime = t1_;
-      dt = (nexttime - time).toSec();
-      const double r = dt / interval;
-      omega_S_1 = ((1.0 - r) * omega_S_0 + r * omega_S_1).eval();
-      acc_S_1 = ((1.0 - r) * acc_S_0 + r * acc_S_1).eval();
-    }
-
-    if (dt <= 0.0) {
-      continue;
-    }
-
-    if (!hasStarted) {
-      hasStarted = true;
-      const double r = dt / (nexttime - it->timeStamp).toSec();
-      omega_S_0 = (r * omega_S_0 + (1.0 - r) * omega_S_1).eval();
-      acc_S_0 = (r * acc_S_0 + (1.0 - r) * acc_S_1).eval();
-    }
-
-    // ensure integrity
-    double gyr_sat_mult = 1.0;
-    double acc_sat_mult = 1.0;
-
-    if (fabs(omega_S_0[0]) > imuParameters_.g_max
-        || fabs(omega_S_0[1]) > imuParameters_.g_max
-        || fabs(omega_S_0[2]) > imuParameters_.g_max
-        || fabs(omega_S_1[0]) > imuParameters_.g_max
-        || fabs(omega_S_1[1]) > imuParameters_.g_max
-        || fabs(omega_S_1[2]) > imuParameters_.g_max) {
-      gyr_sat_mult *= 100;
-      LOG(WARNING)<< "gyr saturation";
-    }
-
-    if (fabs(acc_S_0[0]) > imuParameters_.a_max || fabs(acc_S_0[1]) > imuParameters_.a_max
-        || fabs(acc_S_0[2]) > imuParameters_.a_max
-        || fabs(acc_S_1[0]) > imuParameters_.a_max
-        || fabs(acc_S_1[1]) > imuParameters_.a_max
-        || fabs(acc_S_1[2]) > imuParameters_.a_max) {
-      acc_sat_mult *= 100;
-      LOG(WARNING)<< "acc saturation";
-    }
-
-    // actual propagation
-    // orientation:
-    Eigen::Quaterniond dq;
-    const Eigen::Vector3d omega_S_true = (0.5 * (omega_S_0 + omega_S_1)
-        - speedAndBiases.segment < 3 > (3));
-    const double theta_half = omega_S_true.norm() * 0.5 * dt;
-    const double sinc_theta_half = ode::sinc(theta_half);
-    const double cos_theta_half = cos(theta_half);
-    dq.vec() = sinc_theta_half * omega_S_true * 0.5 * dt;
-    dq.w() = cos_theta_half;
-    Eigen::Quaterniond Delta_q_1 = Delta_q_ * dq;
-    // rotation matrix integral:
-    const Eigen::Matrix3d C = Delta_q_.toRotationMatrix();
-    const Eigen::Matrix3d C_1 = Delta_q_1.toRotationMatrix();
-    const Eigen::Vector3d acc_S_true = (0.5 * (acc_S_0 + acc_S_1)
-        - speedAndBiases.segment < 3 > (6));
-    const Eigen::Matrix3d C_integral_1 = C_integral_ + 0.5 * (C + C_1) * dt;
-    const Eigen::Vector3d acc_integral_1 = acc_integral_
-        + 0.5 * (C + C_1) * acc_S_true * dt;
-    // rotation matrix double integral:
-    C_doubleintegral_ += C_integral_ * dt + 0.25 * (C + C_1) * dt * dt;
-    acc_doubleintegral_ += acc_integral_ * dt
-        + 0.25 * (C + C_1) * acc_S_true * dt * dt;
-
-    // Jacobian parts
-    dalpha_db_g_ += C_1 * okvis::kinematics::rightJacobian(omega_S_true * dt) * dt;
-    const Eigen::Matrix3d cross_1 = dq.inverse().toRotationMatrix() * cross_
-        + okvis::kinematics::rightJacobian(omega_S_true * dt) * dt;
-    const Eigen::Matrix3d acc_S_x = okvis::kinematics::crossMx(acc_S_true);
-    Eigen::Matrix3d dv_db_g_1 = dv_db_g_
-        + 0.5 * dt * (C * acc_S_x * cross_ + C_1 * acc_S_x * cross_1);
-    dp_db_g_ += dt * dv_db_g_
-        + 0.25 * dt * dt * (C * acc_S_x * cross_ + C_1 * acc_S_x * cross_1);
-
-    // covariance propagation
-    Eigen::Matrix<double, 15, 15> F_delta =
-        Eigen::Matrix<double, 15, 15>::Identity();
-    // transform
-    F_delta.block<3, 3>(0, 3) = -okvis::kinematics::crossMx(
-        acc_integral_ * dt + 0.25 * (C + C_1) * acc_S_true * dt * dt);
-    F_delta.block<3, 3>(0, 6) = Eigen::Matrix3d::Identity() * dt;
-    F_delta.block<3, 3>(0, 9) = dt * dv_db_g_
-        + 0.25 * dt * dt * (C * acc_S_x * cross_ + C_1 * acc_S_x * cross_1);
-    F_delta.block<3, 3>(0, 12) = -C_integral_ * dt
-        + 0.25 * (C + C_1) * dt * dt;
-    F_delta.block<3, 3>(3, 9) = -dt * C_1;
-    F_delta.block<3, 3>(6, 3) = -okvis::kinematics::crossMx(
-        0.5 * (C + C_1) * acc_S_true * dt);
-    F_delta.block<3, 3>(6, 9) = 0.5 * dt
-        * (C * acc_S_x * cross_ + C_1 * acc_S_x * cross_1);
-    F_delta.block<3, 3>(6, 12) = -0.5 * (C + C_1) * dt;
-
-    // Q = K * sigma_sq
-    Eigen::Matrix<double,15,15> K0 = Eigen::Matrix<double,15,15>::Zero();
-    Eigen::Matrix<double,15,15> K1 = Eigen::Matrix<double,15,15>::Zero();
-    Eigen::Matrix<double,15,15> K2 = Eigen::Matrix<double,15,15>::Zero();
-    Eigen::Matrix<double,15,15> K3 = Eigen::Matrix<double,15,15>::Zero();
-    K0.block<3,3>(3,3) = gyr_sat_mult*dt * Eigen::Matrix3d::Identity();
-    K1.block<3,3>(0,0) = 0.5 * dt*dt*dt * acc_sat_mult*acc_sat_mult*acc_sat_mult
-        * Eigen::Matrix3d::Identity();
-    K1.block<3,3>(6,6) = acc_sat_mult*dt* Eigen::Matrix3d::Identity();
-    K2.block<3,3>(9,9) = dt * Eigen::Matrix3d::Identity();
-    K3.block<3,3>(12,12) = dt * Eigen::Matrix3d::Identity();
-    dPdsigma_.at(0) = F_delta*dPdsigma_.at(0)*F_delta.transpose() + K0;
-    dPdsigma_.at(1) = F_delta*dPdsigma_.at(1)*F_delta.transpose() + K1;
-    dPdsigma_.at(2) = F_delta*dPdsigma_.at(2)*F_delta.transpose() + K2;
-    dPdsigma_.at(3) = F_delta*dPdsigma_.at(3)*F_delta.transpose() + K3;
-
-    // memory shift
-    Delta_q_ = Delta_q_1;
-    C_integral_ = C_integral_1;
-    acc_integral_ = acc_integral_1;
-    cross_ = cross_1;
-    dv_db_g_ = dv_db_g_1;
-    time = nexttime;
-
-    ++i;
-
-    if (nexttime == t1_)
-      break;
-
-  }
-
-  // get the weighting:
-  // enforce symmetric
-  for(size_t j=0; j<4; ++j) {
-    dPdsigma_.at(j) = 0.5 * dPdsigma_.at(j) + 0.5 * dPdsigma_.at(j).transpose().eval();
-  }
-  P_delta_ = dPdsigma_.at(0)*imuParameters_.sigma_g_c*imuParameters_.sigma_g_c;
-  P_delta_ += dPdsigma_.at(1)*imuParameters_.sigma_a_c*imuParameters_.sigma_a_c;
-  P_delta_ += dPdsigma_.at(2)*imuParameters_.sigma_gw_c*imuParameters_.sigma_gw_c;
-  P_delta_ += dPdsigma_.at(3)*imuParameters_.sigma_aw_c*imuParameters_.sigma_aw_c;
-
-  // calculate inverse and sqrt
-  PseudoInverse::symmSqrtU(P_delta_, squareRootInformation_);
-  information_ = squareRootInformation_.transpose()*squareRootInformation_;
-
-  return i;
-}
-
-// Propagates pose, speeds and biases with given IMU measurements.
-int ImuError::redoPreintegration(const okvis::kinematics::Transformation& /*T_WS*/,
-                                 const okvis::SpeedAndBias & speedAndBiases) const {
-
-  // ensure unique access outside this function...
-
-  // now the propagation
-  okvis::Time time = t0_;
-  okvis::Time end = t1_;
-
-  // sanity check:
-  OKVIS_ASSERT_TRUE_DBG(Exception, imuMeasurements_.front().timeStamp<=time,
-                    imuMeasurements_.front().timeStamp << "<=" <<time)
-  if (!(imuMeasurements_.back().timeStamp >= end)) {
-    OKVIS_THROW_DBG(Exception, imuMeasurements_.back().timeStamp << " >= " << end)
-    return -1;  // nothing to do...
-  }
-
-  // increments (initialise with identity)
-  Delta_q_ = Eigen::Quaterniond(1, 0, 0, 0);
-  C_integral_ = Eigen::Matrix3d::Zero();
-  C_doubleintegral_ = Eigen::Matrix3d::Zero();
-  acc_integral_ = Eigen::Vector3d::Zero();
-  acc_doubleintegral_ = Eigen::Vector3d::Zero();
-
-  // cross matrix accumulatrion
-  cross_ = Eigen::Matrix3d::Zero();
-
-  // sub-Jacobians
-  dalpha_db_g_ = Eigen::Matrix3d::Zero();
-  dv_db_g_ = Eigen::Matrix3d::Zero();
-  dp_db_g_ = Eigen::Matrix3d::Zero();
-
-  // the Jacobian of the increment (w/o biases)
-  P_delta_ = Eigen::Matrix<double, 15, 15>::Zero();
-
-  // derivatives of covariance matrix w.r.t. sigmas
-  dPdsigma_.resize(4);
-  for(size_t j=0; j<4; ++j) {
-    dPdsigma_.at(j).setZero();
-  }
-
-  bool hasStarted = false;
-  int i = 0;
-  for (okvis::ImuMeasurementDeque::const_iterator it = imuMeasurements_.begin();
-      it != imuMeasurements_.end(); ++it) {
-
-    Eigen::Vector3d omega_S_0 = it->measurement.gyroscopes;
-    Eigen::Vector3d acc_S_0 = it->measurement.accelerometers;
-    Eigen::Vector3d omega_S_1 = (it + 1)->measurement.gyroscopes;
-    Eigen::Vector3d acc_S_1 = (it + 1)->measurement.accelerometers;
-
-    // time delta
-    okvis::Time nexttime;
-    if ((it + 1) == imuMeasurements_.end()) {
-      nexttime = t1_;
-    } else
-      nexttime = (it + 1)->timeStamp;
-    double dt = (nexttime - time).toSec();
-
-    if (end < nexttime) {
-      double interval = (nexttime - it->timeStamp).toSec();
-      nexttime = t1_;
-      dt = (nexttime - time).toSec();
-      const double r = dt / interval;
-      omega_S_1 = ((1.0 - r) * omega_S_0 + r * omega_S_1).eval();
-      acc_S_1 = ((1.0 - r) * acc_S_0 + r * acc_S_1).eval();
-    }
-
-    if (dt <= 0.0) {
-      continue;
-    }
-
-    if (!hasStarted) {
-      hasStarted = true;
-      const double r = dt / (nexttime - it->timeStamp).toSec();
-      omega_S_0 = (r * omega_S_0 + (1.0 - r) * omega_S_1).eval();
-      acc_S_0 = (r * acc_S_0 + (1.0 - r) * acc_S_1).eval();
-    }
-
-    // ensure integrity
-    double gyr_sat_mult = 1.0;
-    double acc_sat_mult = 1.0;
-
-    if (fabs(omega_S_0[0]) > imuParameters_.g_max
-        || fabs(omega_S_0[1]) > imuParameters_.g_max
-        || fabs(omega_S_0[2]) > imuParameters_.g_max
-        || fabs(omega_S_1[0]) > imuParameters_.g_max
-        || fabs(omega_S_1[1]) > imuParameters_.g_max
-        || fabs(omega_S_1[2]) > imuParameters_.g_max) {
-      gyr_sat_mult *= 100;
-      LOG(WARNING)<< "gyr saturation";
-    }
-
-    if (fabs(acc_S_0[0]) > imuParameters_.a_max || fabs(acc_S_0[1]) > imuParameters_.a_max
-        || fabs(acc_S_0[2]) > imuParameters_.a_max
-        || fabs(acc_S_1[0]) > imuParameters_.a_max
-        || fabs(acc_S_1[1]) > imuParameters_.a_max
-        || fabs(acc_S_1[2]) > imuParameters_.a_max) {
-      acc_sat_mult *= 100;
-      LOG(WARNING)<< "acc saturation";
-    }
-
-    // actual propagation
-    // orientation:
-    Eigen::Quaterniond dq;
-    const Eigen::Vector3d omega_S_true = (0.5 * (omega_S_0 + omega_S_1)
-        - speedAndBiases.segment < 3 > (3));
-    const double theta_half = omega_S_true.norm() * 0.5 * dt;
-    const double sinc_theta_half = ode::sinc(theta_half);
-    const double cos_theta_half = cos(theta_half);
-    dq.vec() = sinc_theta_half * omega_S_true * 0.5 * dt;
-    dq.w() = cos_theta_half;
-    Eigen::Quaterniond Delta_q_1 = Delta_q_ * dq;
-    // rotation matrix integral:
-    const Eigen::Matrix3d C = Delta_q_.toRotationMatrix();
-    const Eigen::Matrix3d C_1 = Delta_q_1.toRotationMatrix();
-    const Eigen::Vector3d acc_S_true = (0.5 * (acc_S_0 + acc_S_1)
-        - speedAndBiases.segment < 3 > (6));
-    const Eigen::Matrix3d C_integral_1 = C_integral_ + 0.5 * (C + C_1) * dt;
-    const Eigen::Vector3d acc_integral_1 = acc_integral_
-        + 0.5 * (C + C_1) * acc_S_true * dt;
-    // rotation matrix double integral:
-    C_doubleintegral_ += C_integral_ * dt + 0.25 * (C + C_1) * dt * dt;
-    acc_doubleintegral_ += acc_integral_ * dt
-        + 0.25 * (C + C_1) * acc_S_true * dt * dt;
-
-    // Jacobian parts
-    dalpha_db_g_ += C_1 * okvis::kinematics::rightJacobian(omega_S_true * dt) * dt;
-    const Eigen::Matrix3d cross_1 = dq.inverse().toRotationMatrix() * cross_
-        + okvis::kinematics::rightJacobian(omega_S_true * dt) * dt;
-    const Eigen::Matrix3d acc_S_x = okvis::kinematics::crossMx(acc_S_true);
-    Eigen::Matrix3d dv_db_g_1 = dv_db_g_
-        + 0.5 * dt * (C * acc_S_x * cross_ + C_1 * acc_S_x * cross_1);
-    dp_db_g_ += dt * dv_db_g_
-        + 0.25 * dt * dt * (C * acc_S_x * cross_ + C_1 * acc_S_x * cross_1);
-
-    // covariance propagation
-    Eigen::Matrix<double, 15, 15> F_delta =
-        Eigen::Matrix<double, 15, 15>::Identity();
-    // transform
-    F_delta.block<3, 3>(0, 3) = -okvis::kinematics::crossMx(
-        acc_integral_ * dt + 0.25 * (C + C_1) * acc_S_true * dt * dt);
-    F_delta.block<3, 3>(0, 6) = Eigen::Matrix3d::Identity() * dt;
-    F_delta.block<3, 3>(0, 9) = dt * dv_db_g_
-        + 0.25 * dt * dt * (C * acc_S_x * cross_ + C_1 * acc_S_x * cross_1);
-    F_delta.block<3, 3>(0, 12) = -C_integral_ * dt
-        + 0.25 * (C + C_1) * dt * dt;
-    F_delta.block<3, 3>(3, 9) = -dt * C_1;
-    F_delta.block<3, 3>(6, 3) = -okvis::kinematics::crossMx(
-        0.5 * (C + C_1) * acc_S_true * dt);
-    F_delta.block<3, 3>(6, 9) = 0.5 * dt
-        * (C * acc_S_x * cross_ + C_1 * acc_S_x * cross_1);
-    F_delta.block<3, 3>(6, 12) = -0.5 * (C + C_1) * dt;
-
-    // Q = K * sigma_sq
-    Eigen::Matrix<double,15,15> K0 = Eigen::Matrix<double,15,15>::Zero();
-    Eigen::Matrix<double,15,15> K1 = Eigen::Matrix<double,15,15>::Zero();
-    Eigen::Matrix<double,15,15> K2 = Eigen::Matrix<double,15,15>::Zero();
-    Eigen::Matrix<double,15,15> K3 = Eigen::Matrix<double,15,15>::Zero();
-    K0.block<3,3>(3,3) = gyr_sat_mult*dt * Eigen::Matrix3d::Identity();
-    K1.block<3,3>(0,0) = 0.5 * dt*dt*dt * acc_sat_mult*acc_sat_mult*acc_sat_mult
-        * Eigen::Matrix3d::Identity();
-    K1.block<3,3>(6,6) = acc_sat_mult*dt* Eigen::Matrix3d::Identity();
-    K2.block<3,3>(9,9) = dt * Eigen::Matrix3d::Identity();
-    K3.block<3,3>(12,12) = dt * Eigen::Matrix3d::Identity();
-    dPdsigma_.at(0) = F_delta*dPdsigma_.at(0)*F_delta.transpose() + K0;
-    dPdsigma_.at(1) = F_delta*dPdsigma_.at(1)*F_delta.transpose() + K1;
-    dPdsigma_.at(2) = F_delta*dPdsigma_.at(2)*F_delta.transpose() + K2;
-    dPdsigma_.at(3) = F_delta*dPdsigma_.at(3)*F_delta.transpose() + K3;
-
-    //P_delta_ = F_delta * P_delta_ * F_delta.transpose();
-    // add noise. Note that transformations with rotation matrices can be ignored, since the noise
-    // is isotropic.
-    //F_tot = F_delta*F_tot;
-
-    // memory shift
-    Delta_q_ = Delta_q_1;
-    C_integral_ = C_integral_1;
-    acc_integral_ = acc_integral_1;
-    cross_ = cross_1;
-    dv_db_g_ = dv_db_g_1;
-    time = nexttime;
-
-    ++i;
-
-    if (nexttime == t1_)
-      break;
-
-  }
-
-  // store the reference (linearisation) point
-  speedAndBiases_ref_ = speedAndBiases;
-
-  // get the weighting:
-  // enforce symmetric
-  for(size_t j=0; j<4; ++j) {
-    dPdsigma_.at(j) = 0.5 * dPdsigma_.at(j) + 0.5 * dPdsigma_.at(j).transpose().eval();
-  }
-  P_delta_ = dPdsigma_.at(0)*imuParameters_.sigma_g_c*imuParameters_.sigma_g_c;
-  P_delta_ += dPdsigma_.at(1)*imuParameters_.sigma_a_c*imuParameters_.sigma_a_c;
-  P_delta_ += dPdsigma_.at(2)*imuParameters_.sigma_gw_c*imuParameters_.sigma_gw_c;
-  P_delta_ += dPdsigma_.at(3)*imuParameters_.sigma_aw_c*imuParameters_.sigma_aw_c;
-
-  // calculate inverse and sqrt
-  PseudoInverse::symmSqrtU(P_delta_, squareRootInformation_);
-  information_ = squareRootInformation_.transpose()*squareRootInformation_;
-
-  return i;
-}
-
-void ImuError::syncFrom(const ImuError &other)
-{
-  imuParameters_ = other.imuParameters_; // The IMU parameters.
-  imuMeasurements_ = other.imuMeasurements_; // The IMU measurements used. Must span t0_ - t1_.
-  t0_ = other.t0_; // The start time (i.e. time of the first set of states).
-  t1_ = other.t1_; // The end time (i.e. time of the sedond set of states).
-  Delta_q_ = other.Delta_q_; // Intermediate result
-  C_integral_ = other.C_integral_; // Intermediate result
-  C_doubleintegral_ = other.C_doubleintegral_; // Intermediate result
-  acc_integral_ = other.acc_integral_; // Intermediate result
-  acc_doubleintegral_ = other.acc_doubleintegral_; // Intermediate result
-  cross_ = other.cross_; // Intermediate result
-  dalpha_db_g_ = other.dalpha_db_g_; // Intermediate result
-  dv_db_g_ = other.dv_db_g_; // Intermediate result
-  dp_db_g_ = other.dp_db_g_; // Intermediate result
-  P_delta_ = other.P_delta_;
-  speedAndBiases_ref_ = other.speedAndBiases_ref_;
-  redo_ = other.redo_; // Keeps track of whether or not redoPreintegration() needs to be called.
-  redoCounter_ = other.redoCounter_; // Counts the number of preintegrations for statistics.
-  information_ = other.information_; // The information matrix for this error term.
-  squareRootInformation_ = other.squareRootInformation_; // The square root information matrix.
-  dPdsigma_ = other.dPdsigma_;
 }
 
 void ImuError::setImuParameters(const ImuParameters &imuParameters) {
@@ -526,29 +108,296 @@ void ImuError::setImuParameters(const ImuParameters &imuParameters) {
   }
 }
 
+ImuError::PreintegratedMeasurements ImuError::computePreintegratedIncrements(
+  const PreintegratedMeasurements & preintegrated, const ImuSensorReadings & imu, double dt)
+{
+  const auto & w = imu.gyroscopes;
+  const auto & a = imu.accelerometers;
+
+  PreintegratedMeasurements increments;
+
+  increments.Delta_q = kinematics::deltaQ(w * dt);
+
+  // Midpoint preintegrated rotation
+  const Eigen::Matrix3d C =
+    (preintegrated.Delta_q * kinematics::deltaQ(0.5 * w * dt)).toRotationMatrix();
+
+  increments.Delta_p = preintegrated.Delta_v * dt + 0.5 * C * a * dt * dt;
+  increments.Delta_v = C * a * dt;
+
+  return increments;
+}
+
+ImuError::HelperMeasurements ImuError::computeNextHelperMeasurements(
+  const HelperMeasurements & helpers, const ImuSensorReadings & imu, double dt,
+  const Eigen::Matrix3d & C_0, const Eigen::Matrix3d & C_1, const Eigen::Quaterniond & dq)
+{
+  const auto & w = imu.gyroscopes;
+  const auto & a = imu.accelerometers;
+
+  const Eigen::Matrix3d a_wedge = kinematics::crossMx(a * dt);
+
+  // Midpoint preintegrated rotation
+  const Eigen::Matrix3d C = C_0 * kinematics::deltaQ(0.5 * w * dt).toRotationMatrix();
+
+  HelperMeasurements next_helpers = HelperMeasurements::Zero();
+
+  // Sum_{k = i}^{j - 1} Delta_R_ik * dt
+  next_helpers.C_integral = helpers.C_integral + C * dt;
+
+  // Sum_{k = i}^{j - 1} (Sum_{m = i}^{k - 1} Delta_R_im * dt) * dt + 0.5 * Delta_R_ik * dt * dt
+  next_helpers.C_doubleintegral =
+    helpers.C_doubleintegral + helpers.C_integral * dt + 0.5 * C * dt * dt;
+
+  // d Delta_R_ij / d b_g = Sum_{k = i}^{j - 1} Delta_R_ik+1 * JR((w_k - b_w_k) * dt) * dt
+  next_helpers.dalpha_db_g = helpers.dalpha_db_g + C_1 * kinematics::rightJacobian(w * dt) * dt;
+
+  // d Delta_R_ij / d b_g = Sum_{k = i}^{j - 1} Delta_R_k+1j^T JR((w_k - b_w_k) * dt) * dt
+  next_helpers.dq_db_g =
+    dq.inverse().toRotationMatrix() * helpers.dq_db_g + kinematics::rightJacobian(w * dt) * dt;
+
+  // Midpoint of dv_db_g * dq_db_g^-1
+  next_helpers.ddv_db_g =
+    0.5 * (C_0 * a_wedge * helpers.dq_db_g + C_1 * a_wedge * next_helpers.dq_db_g);
+
+  // d Delta_v_ij / d b_g = Sum_{k = i}^{j - 1} Delta_R_ik * (a_k - b_a_k)^ * d Delta_R_ik / d b_g * dt
+  next_helpers.dv_db_g = helpers.dv_db_g + next_helpers.ddv_db_g * dt;
+
+  // dp_db_g_ = d Delta_p_ij / d b_g = Sum_{k = i}^{j - 1} Delta_v_ik * dt + 0.5 * Delta_R_ik * (a_k - b_a_k)^ * d Delta_R_ik / d b_g * dt * dt
+  next_helpers.dp_db_g =
+    helpers.dp_db_g + dt * helpers.dv_db_g + 0.5 * next_helpers.ddv_db_g * dt * dt;
+
+  return next_helpers;
+}
+
+int ImuError::doPropagation(
+  PreintegratedMeasurements & preintegrated, HelperMeasurements & helpers,
+  Eigen::Matrix<double, kNumResiduals, kNumResiduals> & covariance,
+  const ImuParameters & imuParameters, const ImuMeasurementDeque & imuMeasurements,
+  const SpeedAndBias & speedAndBiases, const Time & t0, const Time & t1)
+{
+  Time time = t0;
+  const Time & end = t1;
+
+  bool hasStarted = false;
+  int cnt = 0;
+  for (ImuMeasurementDeque::const_iterator it = imuMeasurements.begin();
+       it != imuMeasurements.end() - 1; ++it) {
+    auto imu_0 = it->measurement;
+    auto imu_1 = (it + 1)->measurement;
+
+    Time current_time = it->timeStamp;
+    Time next_time = (it + 1)->timeStamp;
+    double dt = (next_time - time).toSec();
+
+    if (dt <= 0.0) {
+      continue;
+    }
+
+    if (end < next_time) {
+      double interval = (next_time - it->timeStamp).toSec();
+      next_time = end;
+      dt = (next_time - time).toSec();
+      const double r = dt / interval;
+      imu_1.gyroscopes = ((1.0 - r) * imu_0.gyroscopes + r * imu_1.gyroscopes).eval();
+      imu_1.accelerometers = ((1.0 - r) * imu_0.accelerometers + r * imu_1.accelerometers).eval();
+    }
+
+    if (!hasStarted) {
+      hasStarted = true;
+      if (current_time < time) {
+        const double r = dt / (next_time - it->timeStamp).toSec();
+        imu_0.gyroscopes = (r * imu_0.gyroscopes + (1.0 - r) * imu_1.gyroscopes).eval();
+        imu_0.accelerometers = (r * imu_0.accelerometers + (1.0 - r) * imu_1.accelerometers).eval();
+      }
+    }
+
+    double sigma_g_c = imuParameters.sigma_g_c;
+    double sigma_a_c = imuParameters.sigma_a_c;
+    const double & sigma_gw_c = imuParameters.sigma_gw_c;
+    const double & sigma_aw_c = imuParameters.sigma_aw_c;
+
+    if (
+      imu_0.gyroscopes.cwiseAbs().maxCoeff() > imuParameters.g_max ||
+      imu_1.gyroscopes.cwiseAbs().maxCoeff() > imuParameters.g_max) {
+      sigma_g_c *= 100;
+      LOG(WARNING) << "Gyr saturation - scaling sigma";
+    }
+
+    if (
+      imu_0.accelerometers.cwiseAbs().maxCoeff() > imuParameters.a_max ||
+      imu_1.accelerometers.cwiseAbs().maxCoeff() > imuParameters.a_max) {
+      sigma_a_c *= 100;
+      LOG(WARNING) << "Acc saturation - scaling sigma";
+    }
+
+    ImuSensorReadings imu{
+      0.5 * (imu_0.gyroscopes + imu_1.gyroscopes) - speedAndBiases.segment<3>(3),
+      0.5 * (imu_0.accelerometers + imu_1.accelerometers) - speedAndBiases.segment<3>(6)};
+
+    const auto & w = imu.gyroscopes;
+    const auto & a = imu.accelerometers;
+
+    auto preintegrated_increments = computePreintegratedIncrements(preintegrated, imu, dt);
+    PreintegratedMeasurements next_preintegrated = preintegrated * preintegrated_increments;
+
+    HelperMeasurements next_helpers = computeNextHelperMeasurements(
+      helpers, imu, dt, preintegrated.Delta_q.toRotationMatrix(),
+      next_preintegrated.Delta_q.toRotationMatrix(), preintegrated_increments.Delta_q);
+
+    // TODO(foal): Potential improvement. We compute the same midpoint preintegrated rotation matrix three times.
+    const Eigen::Matrix3d C =
+      (preintegrated.Delta_q * kinematics::deltaQ(0.5 * w * dt)).toRotationMatrix();
+
+    Eigen::Matrix<double, kNumResiduals, kNumResiduals> F_delta =
+      Eigen::Matrix<double, kNumResiduals, kNumResiduals>::Identity();
+    Eigen::Matrix<double, kNumResiduals, kNumResiduals> Q =
+      Eigen::Matrix<double, kNumResiduals, kNumResiduals>::Zero();
+
+    F_delta.block<3, 3>(0, 3) =
+      -kinematics::crossMx(preintegrated.Delta_v * dt + 0.5 * C * a * dt * dt);
+    F_delta.block<3, 3>(0, 6) = Eigen::Matrix3d::Identity() * dt;
+    F_delta.block<3, 3>(0, 9) = dt * helpers.dv_db_g + 0.5 * next_helpers.ddv_db_g * dt * dt;
+    F_delta.block<3, 3>(0, 12) = -helpers.C_integral * dt + 0.5 * C * dt * dt;
+    F_delta.block<3, 3>(3, 9) = -dt * next_preintegrated.Delta_q.toRotationMatrix();
+    F_delta.block<3, 3>(6, 3) = -kinematics::crossMx(preintegrated_increments.Delta_v);
+    F_delta.block<3, 3>(6, 9) = next_helpers.ddv_db_g * dt;
+    F_delta.block<3, 3>(6, 12) = -C * dt;
+
+    Q.block<3, 3>(3, 3) = sigma_g_c * sigma_g_c * dt * Eigen::Matrix3d::Identity();
+    Q.block<3, 3>(6, 6) = sigma_a_c * sigma_a_c * dt * Eigen::Matrix3d::Identity();
+    Q.block<3, 3>(0, 0) = 0.5 * Q.block<3, 3>(6, 6) * dt * dt;
+    Q.block<3, 3>(9, 9) = sigma_gw_c * sigma_gw_c * dt * Eigen::Matrix3d::Identity();
+    Q.block<3, 3>(12, 12) = sigma_aw_c * sigma_aw_c * dt * Eigen::Matrix3d::Identity();
+
+    // Q = K * sigma_sq
+    covariance = F_delta * covariance * F_delta.transpose() + Q;
+
+    // memory shift
+    preintegrated = next_preintegrated;
+    helpers = next_helpers;
+    time = next_time;
+
+    ++cnt;
+
+    if (next_time == end) {
+      break;
+    }
+  }
+
+  covariance = 0.5 * (covariance + covariance.transpose().eval());
+
+  return cnt;
+}
+
+int ImuError::append(
+  const okvis::kinematics::Transformation & /*T_WS*/, const okvis::SpeedAndBias & speedAndBiases,
+  const okvis::ImuMeasurementDeque & imuMeasurements, const okvis::Time & t_1)
+{
+  OKVIS_ASSERT_TRUE_DBG(
+    Exception, t1_ >= imuMeasurements.front().timeStamp,
+    "First IMU measurement included in ImuError is not old enough!")
+
+  OKVIS_ASSERT_TRUE_DBG(
+    Exception, t_1 <= imuMeasurements.back().timeStamp,
+    "Last IMU measurement included in ImuError is not new enough!")
+
+  okvis::Time time = t1_;
+  okvis::Time end = t_1;
+
+  if (imuMeasurements.back().timeStamp < end) {
+    return -1;
+  }
+
+  okvis::ImuMeasurementDeque::const_iterator iter = imuMeasurements.begin();
+  while (iter != imuMeasurements.end()) {
+    if (iter->timeStamp > imuMeasurements_.back().timeStamp) {
+      break;
+    }
+    ++iter;
+  }
+  imuMeasurements_.insert(imuMeasurements_.end(), iter, imuMeasurements.end());
+
+  setT1(t_1);
+
+  const int cnt = doPropagation(
+    preintegrated_, helpers_, P_delta_, imuParameters_, imuMeasurements, speedAndBiases, time, end);
+
+  PseudoInverse::symmSqrtU(P_delta_, squareRootInformation_);
+  information_ = squareRootInformation_.transpose() * squareRootInformation_;
+
+  return cnt;
+}
+
+// Propagates pose, speeds and biases with given IMU measurements.
+int ImuError::redoPreintegration(
+  const okvis::kinematics::Transformation & /*T_WS*/,
+  const okvis::SpeedAndBias & speedAndBiases) const
+{
+  // ensure unique access outside this function...
+
+  okvis::Time time = t0_;
+  okvis::Time end = t1_;
+
+  OKVIS_ASSERT_TRUE_DBG(
+    Exception, time >= imuMeasurements_.front().timeStamp,
+    "First IMU measurement included in ImuError is not old enough!")
+
+  OKVIS_ASSERT_TRUE_DBG(
+    Exception, end <= imuMeasurements_.back().timeStamp,
+    "Last IMU measurement included in ImuError is not new enough!")
+
+  if (!(imuMeasurements_.back().timeStamp >= end)) {
+    return -1;
+  }
+
+  reset();
+
+  const int cnt = doPropagation(
+    preintegrated_, helpers_, P_delta_, imuParameters_, imuMeasurements_, speedAndBiases, time,
+    end);
+
+  PseudoInverse::symmSqrtU(P_delta_, squareRootInformation_);
+  information_ = squareRootInformation_.transpose() * squareRootInformation_;
+
+  // store the reference (linearisation) point
+  speedAndBiases_ref_ = speedAndBiases;
+
+  return cnt;
+}
+
+void ImuError::syncFrom(const ImuError & other)
+{
+  imuParameters_ = other.imuParameters_;
+  imuMeasurements_ = other.imuMeasurements_;
+  t0_ = other.t0_;
+  t1_ = other.t1_;
+  preintegrated_ = other.preintegrated_;
+  helpers_ = other.helpers_;
+  P_delta_ = other.P_delta_;
+  speedAndBiases_ref_ = other.speedAndBiases_ref_;
+  redo_ = other.redo_;
+  redoCounter_ = other.redoCounter_;
+  information_ = other.information_;
+  squareRootInformation_ = other.squareRootInformation_;
+  dPdsigma_ = other.dPdsigma_;
+}
+
 std::shared_ptr<ImuErrorBase> ImuError::clone() const
 {
   std::shared_ptr<ImuError> clone(new ImuError());
-  //clone.
-  clone->imuParameters_ = imuParameters_; // The IMU parameters.
-  clone->imuMeasurements_ = imuMeasurements_; // The IMU measurements used. Must span t0_ - t1_.
-  clone->t0_ = t0_; // The start time (i.e. time of the first set of states).
-  clone->t1_ = t1_; // The end time (i.e. time of the sedond set of states).
-  clone->Delta_q_ = Delta_q_; // Intermediate result
-  clone->C_integral_ = C_integral_; // Intermediate result
-  clone->C_doubleintegral_ = C_doubleintegral_; // Intermediate result
-  clone->acc_integral_ = acc_integral_; // Intermediate result
-  clone->acc_doubleintegral_ = acc_doubleintegral_; // Intermediate result
-  clone->cross_ = cross_; // Intermediate result
-  clone->dalpha_db_g_ = dalpha_db_g_; // Intermediate result
-  clone->dv_db_g_ = dv_db_g_; // Intermediate result
-  clone->dp_db_g_ = dp_db_g_; // Intermediate result
+  clone->imuParameters_ = imuParameters_;
+  clone->imuMeasurements_ = imuMeasurements_;
+  clone->t0_ = t0_;
+  clone->t1_ = t1_;
+  clone->preintegrated_ = preintegrated_;
+  clone->helpers_ = helpers_;
   clone->P_delta_ = P_delta_;
   clone->speedAndBiases_ref_ = speedAndBiases_ref_;
-  clone->redo_ = redo_; // Keeps track of whether or not redoPreintegration() needs to be called.
-  clone->redoCounter_ = redoCounter_; // Counts the number of preintegrations for statistics.
-  clone->information_ = information_; // The information matrix for this error term.
-  clone->squareRootInformation_ = squareRootInformation_; // The square root information matrix.
+  clone->redo_ = redo_;
+  clone->redoCounter_ = redoCounter_;
+  clone->information_ = information_;
+  clone->squareRootInformation_ = squareRootInformation_;
   clone->dPdsigma_ = dPdsigma_;
   return clone;
 }
@@ -885,46 +734,51 @@ bool ImuError::EvaluateWithMinimalJacobians(double const* const * parameters,
     const Eigen::Vector3d g_W = imuParameters_.g * Eigen::Vector3d(0, 0, 6371009).normalized();
 
     // assign Jacobian w.r.t. x0
-    Eigen::Matrix<double,15,15> F0 =
-        Eigen::Matrix<double,15,15>::Identity(); // holds for d/db_g, d/db_a
-    const Eigen::Vector3d delta_p_est_W =
-        T_WS_0.r() - T_WS_1.r() + speedAndBiases_0.head<3>()*Delta_t - 0.5*g_W*Delta_t*Delta_t;
+    Eigen::Matrix<double, 15, 15> F0 =
+      Eigen::Matrix<double, 15, 15>::Identity();  // holds for d/db_g, d/db_a
+    const Eigen::Vector3d delta_p_est_W = T_WS_0.r() - T_WS_1.r() +
+                                          speedAndBiases_0.head<3>() * Delta_t -
+                                          0.5 * g_W * Delta_t * Delta_t;
     const Eigen::Vector3d delta_v_est_W =
-        speedAndBiases_0.head<3>() - speedAndBiases_1.head<3>() - g_W*Delta_t;
+      speedAndBiases_0.head<3>() - speedAndBiases_1.head<3>() - g_W * Delta_t;
     const Eigen::Quaterniond Dq =
-        okvis::kinematics::deltaQ(-dalpha_db_g_*Delta_b.head<3>())*Delta_q_;
-    F0.block<3,3>(0,0) = C_S0_W;
-    F0.block<3,3>(0,3) = C_S0_W * okvis::kinematics::crossMx(delta_p_est_W);
-    F0.block<3,3>(0,6) = C_S0_W * Eigen::Matrix3d::Identity()*Delta_t;
-    F0.block<3,3>(0,9) = dp_db_g_;
-    F0.block<3,3>(0,12) = -C_doubleintegral_;
-    F0.block<3,3>(3,3) = (okvis::kinematics::plus(Dq*T_WS_1.q().inverse()) *
-        okvis::kinematics::oplus(T_WS_0.q())).topLeftCorner<3,3>();
-    F0.block<3,3>(3,9) = (okvis::kinematics::oplus(T_WS_1.q().inverse()*T_WS_0.q())*
-        okvis::kinematics::oplus(Dq)).topLeftCorner<3,3>()*(-dalpha_db_g_);
-    F0.block<3,3>(6,3) = C_S0_W * okvis::kinematics::crossMx(delta_v_est_W);
-    F0.block<3,3>(6,6) = C_S0_W;
-    F0.block<3,3>(6,9) = dv_db_g_;
-    F0.block<3,3>(6,12) = -C_integral_;
+      okvis::kinematics::deltaQ(-helpers_.dalpha_db_g * Delta_b.head<3>()) * preintegrated_.Delta_q;
+    F0.block<3, 3>(0, 0) = C_S0_W;
+    F0.block<3, 3>(0, 3) = C_S0_W * okvis::kinematics::crossMx(delta_p_est_W);
+    F0.block<3, 3>(0, 6) = C_S0_W * Eigen::Matrix3d::Identity() * Delta_t;
+    F0.block<3, 3>(0, 9) = helpers_.dp_db_g;
+    F0.block<3, 3>(0, 12) = -helpers_.C_doubleintegral;
+    F0.block<3, 3>(3, 3) =
+      (okvis::kinematics::plus(Dq * T_WS_1.q().inverse()) * okvis::kinematics::oplus(T_WS_0.q()))
+        .topLeftCorner<3, 3>();
+    F0.block<3, 3>(3, 9) =
+      (okvis::kinematics::oplus(T_WS_1.q().inverse() * T_WS_0.q()) * okvis::kinematics::oplus(Dq))
+        .topLeftCorner<3, 3>() *
+      (-helpers_.dalpha_db_g);
+    F0.block<3, 3>(6, 3) = C_S0_W * okvis::kinematics::crossMx(delta_v_est_W);
+    F0.block<3, 3>(6, 6) = C_S0_W;
+    F0.block<3, 3>(6, 9) = helpers_.dv_db_g;
+    F0.block<3, 3>(6, 12) = -helpers_.C_integral;
 
     // assign Jacobian w.r.t. x1
-    Eigen::Matrix<double,15,15> F1 =
-        -Eigen::Matrix<double,15,15>::Identity(); // holds for the biases
-    F1.block<3,3>(0,0) = -C_S0_W;
-    F1.block<3,3>(3,3) = -(okvis::kinematics::plus(Dq) *
-        okvis::kinematics::oplus(T_WS_0.q()) *
-        okvis::kinematics::plus(T_WS_1.q().inverse())).topLeftCorner<3,3>();
-    F1.block<3,3>(6,6) = -C_S0_W;
+    Eigen::Matrix<double, 15, 15> F1 =
+      -Eigen::Matrix<double, 15, 15>::Identity();  // holds for the biases
+    F1.block<3, 3>(0, 0) = -C_S0_W;
+    F1.block<3, 3>(3, 3) = -(okvis::kinematics::plus(Dq) * okvis::kinematics::oplus(T_WS_0.q()) *
+                             okvis::kinematics::plus(T_WS_1.q().inverse()))
+                              .topLeftCorner<3, 3>();
+    F1.block<3, 3>(6, 6) = -C_S0_W;
 
     // the overall error vector
     Eigen::Matrix<double, 15, 1> error;
-    error.segment<3>(0) =  C_S0_W * delta_p_est_W + acc_doubleintegral_
-        + F0.block<3,6>(0,9)*Delta_b;
-    error.segment<3>(3) = 2*(Dq*(T_WS_1.q().inverse()*T_WS_0.q())).vec();
-    error.segment<3>(6) = C_S0_W * delta_v_est_W + acc_integral_ + F0.block<3,6>(6,9)*Delta_b;
+    error.segment<3>(0) =
+      C_S0_W * delta_p_est_W + preintegrated_.Delta_p + F0.block<3, 6>(0, 9) * Delta_b;
+    error.segment<3>(3) = 2 * (Dq * (T_WS_1.q().inverse() * T_WS_0.q())).vec();
+    error.segment<3>(6) =
+      C_S0_W * delta_v_est_W + preintegrated_.Delta_v + F0.block<3, 6>(6, 9) * Delta_b;
     error.tail<6>() = speedAndBiases_0.tail<6>() - speedAndBiases_1.tail<6>();
     if (!success) {
-      error.setZero(); // disable
+      error.setZero();  // disable
     }
 
     // error weighting
@@ -934,23 +788,21 @@ bool ImuError::EvaluateWithMinimalJacobians(double const* const * parameters,
     if (jacobians != nullptr) {
       if (jacobians[0] != nullptr) {
         // Jacobian w.r.t. minimal perturbance
-        Eigen::Matrix<double, 15, 6> J0_minimal = squareRootInformation_
-            * F0.block<15, 6>(0, 0);
+        Eigen::Matrix<double, 15, 6> J0_minimal = squareRootInformation_ * F0.block<15, 6>(0, 0);
 
         // pseudo inverse of the local parametrization Jacobian:
         Eigen::Matrix<double, 6, 7, Eigen::RowMajor> J_lift;
         PoseManifold::minusJacobian(parameters[0], J_lift.data());
 
         // hallucinate Jacobian w.r.t. state
-        Eigen::Map<Eigen::Matrix<double, 15, 7, Eigen::RowMajor> > J0(
-            jacobians[0]);
+        Eigen::Map<Eigen::Matrix<double, 15, 7, Eigen::RowMajor>> J0(jacobians[0]);
         J0 = J0_minimal * J_lift;
 
         // if requested, provide minimal Jacobians
         if (jacobiansMinimal != nullptr) {
           if (jacobiansMinimal[0] != nullptr) {
-            Eigen::Map<Eigen::Matrix<double, 15, 6, Eigen::RowMajor> > J0_minimal_mapped(
-                jacobiansMinimal[0]);
+            Eigen::Map<Eigen::Matrix<double, 15, 6, Eigen::RowMajor>> J0_minimal_mapped(
+              jacobiansMinimal[0]);
             J0_minimal_mapped = J0_minimal;
             if (!success) {
               J0_minimal_mapped.setZero();
@@ -959,15 +811,14 @@ bool ImuError::EvaluateWithMinimalJacobians(double const* const * parameters,
         }
       }
       if (jacobians[1] != nullptr) {
-        Eigen::Map<Eigen::Matrix<double, 15, 9, Eigen::RowMajor> > J1(
-            jacobians[1]);
+        Eigen::Map<Eigen::Matrix<double, 15, 9, Eigen::RowMajor>> J1(jacobians[1]);
         J1 = squareRootInformation_ * F0.block<15, 9>(0, 6);
 
         // if requested, provide minimal Jacobians
         if (jacobiansMinimal != nullptr) {
           if (jacobiansMinimal[1] != nullptr) {
-            Eigen::Map<Eigen::Matrix<double, 15, 9, Eigen::RowMajor> > J1_minimal_mapped(
-                jacobiansMinimal[1]);
+            Eigen::Map<Eigen::Matrix<double, 15, 9, Eigen::RowMajor>> J1_minimal_mapped(
+              jacobiansMinimal[1]);
             J1_minimal_mapped = J1;
             if (!success) {
               J1_minimal_mapped.setZero();
@@ -977,23 +828,21 @@ bool ImuError::EvaluateWithMinimalJacobians(double const* const * parameters,
       }
       if (jacobians[2] != nullptr) {
         // Jacobian w.r.t. minimal perturbance
-        Eigen::Matrix<double, 15, 6> J2_minimal = squareRootInformation_
-                    * F1.block<15, 6>(0, 0);
+        Eigen::Matrix<double, 15, 6> J2_minimal = squareRootInformation_ * F1.block<15, 6>(0, 0);
 
         // pseudo inverse of the local parametrization Jacobian:
         Eigen::Matrix<double, 6, 7, Eigen::RowMajor> J_lift;
         PoseManifold::minusJacobian(parameters[2], J_lift.data());
 
         // hallucinate Jacobian w.r.t. state
-        Eigen::Map<Eigen::Matrix<double, 15, 7, Eigen::RowMajor> > J2(
-            jacobians[2]);
+        Eigen::Map<Eigen::Matrix<double, 15, 7, Eigen::RowMajor>> J2(jacobians[2]);
         J2 = J2_minimal * J_lift;
 
         // if requested, provide minimal Jacobians
         if (jacobiansMinimal != nullptr) {
           if (jacobiansMinimal[2] != nullptr) {
-            Eigen::Map<Eigen::Matrix<double, 15, 6, Eigen::RowMajor> > J2_minimal_mapped(
-                jacobiansMinimal[2]);
+            Eigen::Map<Eigen::Matrix<double, 15, 6, Eigen::RowMajor>> J2_minimal_mapped(
+              jacobiansMinimal[2]);
             J2_minimal_mapped = J2_minimal;
             if (!success) {
               J2_minimal_mapped.setZero();
@@ -1002,14 +851,14 @@ bool ImuError::EvaluateWithMinimalJacobians(double const* const * parameters,
         }
       }
       if (jacobians[3] != nullptr) {
-        Eigen::Map<Eigen::Matrix<double, 15, 9, Eigen::RowMajor> > J3(jacobians[3]);
+        Eigen::Map<Eigen::Matrix<double, 15, 9, Eigen::RowMajor>> J3(jacobians[3]);
         J3 = squareRootInformation_ * F1.block<15, 9>(0, 6);
 
         // if requested, provide minimal Jacobians
         if (jacobiansMinimal != nullptr) {
           if (jacobiansMinimal[3] != nullptr) {
-            Eigen::Map<Eigen::Matrix<double, 15, 9, Eigen::RowMajor> > J3_minimal_mapped(
-                jacobiansMinimal[3]);
+            Eigen::Map<Eigen::Matrix<double, 15, 9, Eigen::RowMajor>> J3_minimal_mapped(
+              jacobiansMinimal[3]);
             J3_minimal_mapped = J3;
             if (!success) {
               J3_minimal_mapped.setZero();
@@ -1065,47 +914,52 @@ bool ImuError::EvaluateWithSigmaGradientAndHessian(const double * const *paramet
     const Eigen::Vector3d g_W = imuParameters_.g * Eigen::Vector3d(0, 0, 6371009).normalized();
 
     // assign Jacobian w.r.t. x0
-    Eigen::Matrix<double,15,15> F0 =
-        Eigen::Matrix<double,15,15>::Identity(); // holds for d/db_g, d/db_a
-    const Eigen::Vector3d delta_p_est_W =
-        T_WS_0.r() - T_WS_1.r() + speedAndBiases_0.head<3>()*Delta_t - 0.5*g_W*Delta_t*Delta_t;
+    Eigen::Matrix<double, 15, 15> F0 =
+      Eigen::Matrix<double, 15, 15>::Identity();  // holds for d/db_g, d/db_a
+    const Eigen::Vector3d delta_p_est_W = T_WS_0.r() - T_WS_1.r() +
+                                          speedAndBiases_0.head<3>() * Delta_t -
+                                          0.5 * g_W * Delta_t * Delta_t;
     const Eigen::Vector3d delta_v_est_W =
-        speedAndBiases_0.head<3>() - speedAndBiases_1.head<3>() - g_W*Delta_t;
+      speedAndBiases_0.head<3>() - speedAndBiases_1.head<3>() - g_W * Delta_t;
     const Eigen::Quaterniond Dq =
-        okvis::kinematics::deltaQ(-dalpha_db_g_*Delta_b.head<3>())*Delta_q_;
-    F0.block<3,3>(0,0) = C_S0_W;
-    F0.block<3,3>(0,3) = C_S0_W * okvis::kinematics::crossMx(delta_p_est_W);
-    F0.block<3,3>(0,6) = C_S0_W * Eigen::Matrix3d::Identity()*Delta_t;
-    F0.block<3,3>(0,9) = dp_db_g_;
-    F0.block<3,3>(0,12) = -C_doubleintegral_;
-    F0.block<3,3>(3,3) = (okvis::kinematics::plus(Dq*T_WS_1.q().inverse()) *
-        okvis::kinematics::oplus(T_WS_0.q())).topLeftCorner<3,3>();
-    F0.block<3,3>(3,9) = (okvis::kinematics::oplus(T_WS_1.q().inverse()*T_WS_0.q())*
-        okvis::kinematics::oplus(Dq)).topLeftCorner<3,3>()*(-dalpha_db_g_);
-    F0.block<3,3>(6,3) = C_S0_W * okvis::kinematics::crossMx(delta_v_est_W);
-    F0.block<3,3>(6,6) = C_S0_W;
-    F0.block<3,3>(6,9) = dv_db_g_;
-    F0.block<3,3>(6,12) = -C_integral_;
+      okvis::kinematics::deltaQ(-helpers_.dalpha_db_g * Delta_b.head<3>()) * preintegrated_.Delta_q;
+    F0.block<3, 3>(0, 0) = C_S0_W;
+    F0.block<3, 3>(0, 3) = C_S0_W * okvis::kinematics::crossMx(delta_p_est_W);
+    F0.block<3, 3>(0, 6) = C_S0_W * Eigen::Matrix3d::Identity() * Delta_t;
+    F0.block<3, 3>(0, 9) = helpers_.dp_db_g;
+    F0.block<3, 3>(0, 12) = -helpers_.C_doubleintegral;
+    F0.block<3, 3>(3, 3) =
+      (okvis::kinematics::plus(Dq * T_WS_1.q().inverse()) * okvis::kinematics::oplus(T_WS_0.q()))
+        .topLeftCorner<3, 3>();
+    F0.block<3, 3>(3, 9) =
+      (okvis::kinematics::oplus(T_WS_1.q().inverse() * T_WS_0.q()) * okvis::kinematics::oplus(Dq))
+        .topLeftCorner<3, 3>() *
+      (-helpers_.dalpha_db_g);
+    F0.block<3, 3>(6, 3) = C_S0_W * okvis::kinematics::crossMx(delta_v_est_W);
+    F0.block<3, 3>(6, 6) = C_S0_W;
+    F0.block<3, 3>(6, 9) = helpers_.dv_db_g;
+    F0.block<3, 3>(6, 12) = -helpers_.C_integral;
 
     // assign Jacobian w.r.t. x1
-    Eigen::Matrix<double,15,15> F1 =
-        -Eigen::Matrix<double,15,15>::Identity(); // holds for the biases
-    F1.block<3,3>(0,0) = -C_S0_W;
-    F1.block<3,3>(3,3) = -(okvis::kinematics::plus(Dq) *
-        okvis::kinematics::oplus(T_WS_0.q()) *
-        okvis::kinematics::plus(T_WS_1.q().inverse())).topLeftCorner<3,3>();
-    F1.block<3,3>(6,6) = -C_S0_W;
+    Eigen::Matrix<double, 15, 15> F1 =
+      -Eigen::Matrix<double, 15, 15>::Identity();  // holds for the biases
+    F1.block<3, 3>(0, 0) = -C_S0_W;
+    F1.block<3, 3>(3, 3) = -(okvis::kinematics::plus(Dq) * okvis::kinematics::oplus(T_WS_0.q()) *
+                             okvis::kinematics::plus(T_WS_1.q().inverse()))
+                              .topLeftCorner<3, 3>();
+    F1.block<3, 3>(6, 6) = -C_S0_W;
 
     // the overall error vector
-    error.segment<3>(0) =  C_S0_W * delta_p_est_W + acc_doubleintegral_
-        + F0.block<3,6>(0,9)*Delta_b;
-    error.segment<3>(3) = 2*(Dq*(T_WS_1.q().inverse()*T_WS_0.q())).vec();
-    error.segment<3>(6) = C_S0_W * delta_v_est_W + acc_integral_ + F0.block<3,6>(6,9)*Delta_b;
+    error.segment<3>(0) =
+      C_S0_W * delta_p_est_W + preintegrated_.Delta_p + F0.block<3, 6>(0, 9) * Delta_b;
+    error.segment<3>(3) = 2 * (Dq * (T_WS_1.q().inverse() * T_WS_0.q())).vec();
+    error.segment<3>(6) =
+      C_S0_W * delta_v_est_W + preintegrated_.Delta_v + F0.block<3, 6>(6, 9) * Delta_b;
     error.tail<6>() = speedAndBiases_0.tail<6>() - speedAndBiases_1.tail<6>();
   }
 
   // evaluate cost
-  *cost = 0.5*(error.transpose()*information_*error + log(P_delta_.determinant()));
+  *cost = 0.5 * (error.transpose() * information_ * error + log(P_delta_.determinant()));
 
   // evaluate gradient and Hessian
   // sigma = [sigma_g_c, sigma_a_c, sigma_gw_c, sigma_aw_c]
@@ -1115,27 +969,29 @@ bool ImuError::EvaluateWithSigmaGradientAndHessian(const double * const *paramet
   // sigma_aw_c: accelerometer drift noise density [m/s^2/sqrt(Hz)]
   Eigen::Map<Eigen::Matrix<double, 4, 1>> gradientVec(gradient);
   Eigen::Map<Eigen::Matrix<double, 4, 4>> hessianMat(hessian);
-  for(size_t j = 0; j<4; ++j) {
-
-    Eigen::Matrix<double, 15, 1> inf_e = information_*error;
+  for (size_t j = 0; j < 4; ++j) {
+    Eigen::Matrix<double, 15, 1> inf_e = information_ * error;
     //Eigen::Matrix<double, 15, 15> Z = information_*dPdsigma_.at(j)*information_;
-    Eigen::Matrix<double, 15, 15> Y = information_*dPdsigma_.at(j);
-    gradientVec[int(j)] = 0.5*(-inf_e.transpose()*dPdsigma_.at(j)*inf_e + Y.trace());
+    Eigen::Matrix<double, 15, 15> Y = information_ * dPdsigma_.at(j);
+    gradientVec[int(j)] = 0.5 * (-inf_e.transpose() * dPdsigma_.at(j) * inf_e + Y.trace());
     // evaluate Hessian
     // diagonal first: dcost/dsigma_j^2
     //Eigen::Matrix<double, 15, 15> Zdash
     // = -Z*dPdsigma_.at(j)*information_ - information_*dPdsigma_.at(j)*Z;
-    Eigen::Matrix<double, 15, 15> Ydash = -Y*information_*dPdsigma_.at(j);
-    hessianMat(int(j),int(j)) = 0.5*(2*(inf_e.transpose()*dPdsigma_.at(j))*information_
-                                     *(dPdsigma_.at(j)*inf_e) + Ydash.trace());
-    for(size_t k = 0; k<j; ++k) {
+    Eigen::Matrix<double, 15, 15> Ydash = -Y * information_ * dPdsigma_.at(j);
+    hessianMat(int(j), int(j)) =
+      0.5 * (2 * (inf_e.transpose() * dPdsigma_.at(j)) * information_ * (dPdsigma_.at(j) * inf_e) +
+             Ydash.trace());
+    for (size_t k = 0; k < j; ++k) {
       // off-diagonal entries
       //Zdash = -Z*dPdsigma_.at(j)*information_ - information_*dPdsigma_.at(k)*Z;
-      Ydash = -Y*information_*dPdsigma_.at(k);
-      const double t0 = ((inf_e.transpose()*dPdsigma_.at(j))*information_*(dPdsigma_.at(k)*inf_e));
-      const double t1 = ((inf_e.transpose()*dPdsigma_.at(k))*information_*(dPdsigma_.at(j)*inf_e));
-      hessianMat(int(j),int(k)) = 0.5*(t0 + t1 + Ydash.trace());
-      hessianMat(int(k),int(j)) = hessianMat(int(j),int(k));
+      Ydash = -Y * information_ * dPdsigma_.at(k);
+      const double t0 =
+        ((inf_e.transpose() * dPdsigma_.at(j)) * information_ * (dPdsigma_.at(k) * inf_e));
+      const double t1 =
+        ((inf_e.transpose() * dPdsigma_.at(k)) * information_ * (dPdsigma_.at(j) * inf_e));
+      hessianMat(int(j), int(k)) = 0.5 * (t0 + t1 + Ydash.trace());
+      hessianMat(int(k), int(j)) = hessianMat(int(j), int(k));
     }
   }
 

--- a/okvis_ceres/src/ImuError.cpp
+++ b/okvis_ceres/src/ImuError.cpp
@@ -442,7 +442,8 @@ int ImuError::propagation(const okvis::ImuMeasurementDeque & imuMeasurements,
   Eigen::Matrix3d dp_db_g = Eigen::Matrix3d::Zero();
 
   // the Jacobian of the increment (w/o biases)
-  Eigen::Matrix<double,15,15> P_delta = Eigen::Matrix<double,15,15>::Zero();
+  Eigen::Matrix<double, kNumResiduals, kNumResiduals> P_delta =
+    Eigen::Matrix<double, kNumResiduals, kNumResiduals>::Zero();
 
   double Delta_t = 0;
   bool hasStarted = false;
@@ -538,7 +539,8 @@ int ImuError::propagation(const okvis::ImuMeasurementDeque & imuMeasurements,
 
     // covariance propagation
     if (covariance) {
-      Eigen::Matrix<double,15,15> F_delta = Eigen::Matrix<double,15,15>::Identity();
+      Eigen::Matrix<double, kNumResiduals, kNumResiduals> F_delta =
+        Eigen::Matrix<double, kNumResiduals, kNumResiduals>::Identity();
       // transform
       F_delta.block<3,3>(0,3) = -okvis::kinematics::crossMx(
             acc_integral*dt + 0.25*(C + C_1)*acc_S_true*dt*dt);
@@ -602,7 +604,7 @@ int ImuError::propagation(const okvis::ImuMeasurementDeque & imuMeasurements,
 
   // assign Jacobian, if requested
   if (jacobian) {
-    Eigen::Matrix<double,15,15> & F = *jacobian;
+    Eigen::Matrix<double, kNumResiduals, kNumResiduals> & F = *jacobian;
     F.setIdentity(); // holds for all states, including d/dalpha, d/db_g, d/db_a
     F.block<3,3>(0,3) = -okvis::kinematics::crossMx(C_WS_0*acc_doubleintegral);
     F.block<3,3>(0,6) = Eigen::Matrix3d::Identity()*Delta_t;
@@ -616,9 +618,10 @@ int ImuError::propagation(const okvis::ImuMeasurementDeque & imuMeasurements,
 
   // overall covariance, if requested
   if (covariance) {
-    Eigen::Matrix<double,15,15> & P = *covariance;
+    Eigen::Matrix<double, kNumResiduals, kNumResiduals> & P = *covariance;
     // transform from local increments to actual states
-    Eigen::Matrix<double,15,15> T = Eigen::Matrix<double,15,15>::Identity();
+    Eigen::Matrix<double, kNumResiduals, kNumResiduals> T =
+      Eigen::Matrix<double, kNumResiduals, kNumResiduals>::Identity();
     T.topLeftCorner<3,3>() = C_WS_0;
     T.block<3,3>(3,3) = C_WS_0;
     T.block<3,3>(6,6) = C_WS_0;
@@ -669,7 +672,7 @@ bool ImuError::EvaluateWithMinimalJacobians(double const* const * parameters,
                                             double** jacobiansMinimal) const {
   bool success = true;
 
-  Eigen::Map<Eigen::Matrix<double, 15, 1> > weighted_error(residuals);
+  Eigen::Map<Eigen::Matrix<double, kNumResiduals, 1> > weighted_error(residuals);
 
   // get poses
   const okvis::kinematics::Transformation T_WS_0(
@@ -734,8 +737,8 @@ bool ImuError::EvaluateWithMinimalJacobians(double const* const * parameters,
     const Eigen::Vector3d g_W = imuParameters_.g * Eigen::Vector3d(0, 0, 6371009).normalized();
 
     // assign Jacobian w.r.t. x0
-    Eigen::Matrix<double, 15, 15> F0 =
-      Eigen::Matrix<double, 15, 15>::Identity();  // holds for d/db_g, d/db_a
+    Eigen::Matrix<double, kNumResiduals, kNumResiduals> F0 =
+      Eigen::Matrix<double, kNumResiduals, kNumResiduals>::Identity();  // holds for d/db_g, d/db_a
     const Eigen::Vector3d delta_p_est_W = T_WS_0.r() - T_WS_1.r() +
                                           speedAndBiases_0.head<3>() * Delta_t -
                                           0.5 * g_W * Delta_t * Delta_t;
@@ -761,8 +764,8 @@ bool ImuError::EvaluateWithMinimalJacobians(double const* const * parameters,
     F0.block<3, 3>(6, 12) = -helpers_.C_integral;
 
     // assign Jacobian w.r.t. x1
-    Eigen::Matrix<double, 15, 15> F1 =
-      -Eigen::Matrix<double, 15, 15>::Identity();  // holds for the biases
+    Eigen::Matrix<double, kNumResiduals, kNumResiduals> F1 =
+      -Eigen::Matrix<double, kNumResiduals, kNumResiduals>::Identity();  // holds for the biases
     F1.block<3, 3>(0, 0) = -C_S0_W;
     F1.block<3, 3>(3, 3) = -(okvis::kinematics::plus(Dq) * okvis::kinematics::oplus(T_WS_0.q()) *
                              okvis::kinematics::plus(T_WS_1.q().inverse()))
@@ -770,7 +773,7 @@ bool ImuError::EvaluateWithMinimalJacobians(double const* const * parameters,
     F1.block<3, 3>(6, 6) = -C_S0_W;
 
     // the overall error vector
-    Eigen::Matrix<double, 15, 1> error;
+    Eigen::Matrix<double, kNumResiduals, 1> error;
     error.segment<3>(0) =
       C_S0_W * delta_p_est_W + preintegrated_.Delta_p + F0.block<3, 6>(0, 9) * Delta_b;
     error.segment<3>(3) = 2 * (Dq * (T_WS_1.q().inverse() * T_WS_0.q())).vec();
@@ -788,20 +791,21 @@ bool ImuError::EvaluateWithMinimalJacobians(double const* const * parameters,
     if (jacobians != nullptr) {
       if (jacobians[0] != nullptr) {
         // Jacobian w.r.t. minimal perturbance
-        Eigen::Matrix<double, 15, 6> J0_minimal = squareRootInformation_ * F0.block<15, 6>(0, 0);
+        Eigen::Matrix<double, kNumResiduals, 6> J0_minimal =
+          squareRootInformation_ * F0.block<kNumResiduals, 6>(0, 0);
 
         // pseudo inverse of the local parametrization Jacobian:
         Eigen::Matrix<double, 6, 7, Eigen::RowMajor> J_lift;
         PoseManifold::minusJacobian(parameters[0], J_lift.data());
 
         // hallucinate Jacobian w.r.t. state
-        Eigen::Map<Eigen::Matrix<double, 15, 7, Eigen::RowMajor>> J0(jacobians[0]);
+        Eigen::Map<Eigen::Matrix<double, kNumResiduals, 7, Eigen::RowMajor>> J0(jacobians[0]);
         J0 = J0_minimal * J_lift;
 
         // if requested, provide minimal Jacobians
         if (jacobiansMinimal != nullptr) {
           if (jacobiansMinimal[0] != nullptr) {
-            Eigen::Map<Eigen::Matrix<double, 15, 6, Eigen::RowMajor>> J0_minimal_mapped(
+            Eigen::Map<Eigen::Matrix<double, kNumResiduals, 6, Eigen::RowMajor>> J0_minimal_mapped(
               jacobiansMinimal[0]);
             J0_minimal_mapped = J0_minimal;
             if (!success) {
@@ -811,13 +815,13 @@ bool ImuError::EvaluateWithMinimalJacobians(double const* const * parameters,
         }
       }
       if (jacobians[1] != nullptr) {
-        Eigen::Map<Eigen::Matrix<double, 15, 9, Eigen::RowMajor>> J1(jacobians[1]);
-        J1 = squareRootInformation_ * F0.block<15, 9>(0, 6);
+        Eigen::Map<Eigen::Matrix<double, kNumResiduals, 9, Eigen::RowMajor>> J1(jacobians[1]);
+        J1 = squareRootInformation_ * F0.block<kNumResiduals, 9>(0, 6);
 
         // if requested, provide minimal Jacobians
         if (jacobiansMinimal != nullptr) {
           if (jacobiansMinimal[1] != nullptr) {
-            Eigen::Map<Eigen::Matrix<double, 15, 9, Eigen::RowMajor>> J1_minimal_mapped(
+            Eigen::Map<Eigen::Matrix<double, kNumResiduals, 9, Eigen::RowMajor>> J1_minimal_mapped(
               jacobiansMinimal[1]);
             J1_minimal_mapped = J1;
             if (!success) {
@@ -828,20 +832,21 @@ bool ImuError::EvaluateWithMinimalJacobians(double const* const * parameters,
       }
       if (jacobians[2] != nullptr) {
         // Jacobian w.r.t. minimal perturbance
-        Eigen::Matrix<double, 15, 6> J2_minimal = squareRootInformation_ * F1.block<15, 6>(0, 0);
+        Eigen::Matrix<double, kNumResiduals, 6> J2_minimal =
+          squareRootInformation_ * F1.block<kNumResiduals, 6>(0, 0);
 
         // pseudo inverse of the local parametrization Jacobian:
         Eigen::Matrix<double, 6, 7, Eigen::RowMajor> J_lift;
         PoseManifold::minusJacobian(parameters[2], J_lift.data());
 
         // hallucinate Jacobian w.r.t. state
-        Eigen::Map<Eigen::Matrix<double, 15, 7, Eigen::RowMajor>> J2(jacobians[2]);
+        Eigen::Map<Eigen::Matrix<double, kNumResiduals, 7, Eigen::RowMajor>> J2(jacobians[2]);
         J2 = J2_minimal * J_lift;
 
         // if requested, provide minimal Jacobians
         if (jacobiansMinimal != nullptr) {
           if (jacobiansMinimal[2] != nullptr) {
-            Eigen::Map<Eigen::Matrix<double, 15, 6, Eigen::RowMajor>> J2_minimal_mapped(
+            Eigen::Map<Eigen::Matrix<double, kNumResiduals, 6, Eigen::RowMajor>> J2_minimal_mapped(
               jacobiansMinimal[2]);
             J2_minimal_mapped = J2_minimal;
             if (!success) {
@@ -851,13 +856,13 @@ bool ImuError::EvaluateWithMinimalJacobians(double const* const * parameters,
         }
       }
       if (jacobians[3] != nullptr) {
-        Eigen::Map<Eigen::Matrix<double, 15, 9, Eigen::RowMajor>> J3(jacobians[3]);
-        J3 = squareRootInformation_ * F1.block<15, 9>(0, 6);
+        Eigen::Map<Eigen::Matrix<double, kNumResiduals, 9, Eigen::RowMajor>> J3(jacobians[3]);
+        J3 = squareRootInformation_ * F1.block<kNumResiduals, 9>(0, 6);
 
         // if requested, provide minimal Jacobians
         if (jacobiansMinimal != nullptr) {
           if (jacobiansMinimal[3] != nullptr) {
-            Eigen::Map<Eigen::Matrix<double, 15, 9, Eigen::RowMajor>> J3_minimal_mapped(
+            Eigen::Map<Eigen::Matrix<double, kNumResiduals, 9, Eigen::RowMajor>> J3_minimal_mapped(
               jacobiansMinimal[3]);
             J3_minimal_mapped = J3;
             if (!success) {
@@ -907,15 +912,15 @@ bool ImuError::EvaluateWithSigmaGradientAndHessian(const double * const *paramet
   }
 
   // actual propagation output:
-  Eigen::Matrix<double, 15, 1> error;
+  Eigen::Matrix<double, kNumResiduals, 1> error;
   {
     std::lock_guard<std::mutex> lock(preintegrationMutex_);
     // the above is a bit stupid, but shared read-locks only come in C++14
     const Eigen::Vector3d g_W = imuParameters_.g * Eigen::Vector3d(0, 0, 6371009).normalized();
 
     // assign Jacobian w.r.t. x0
-    Eigen::Matrix<double, 15, 15> F0 =
-      Eigen::Matrix<double, 15, 15>::Identity();  // holds for d/db_g, d/db_a
+    Eigen::Matrix<double, kNumResiduals, kNumResiduals> F0 =
+      Eigen::Matrix<double, kNumResiduals, kNumResiduals>::Identity();  // holds for d/db_g, d/db_a
     const Eigen::Vector3d delta_p_est_W = T_WS_0.r() - T_WS_1.r() +
                                           speedAndBiases_0.head<3>() * Delta_t -
                                           0.5 * g_W * Delta_t * Delta_t;
@@ -941,8 +946,8 @@ bool ImuError::EvaluateWithSigmaGradientAndHessian(const double * const *paramet
     F0.block<3, 3>(6, 12) = -helpers_.C_integral;
 
     // assign Jacobian w.r.t. x1
-    Eigen::Matrix<double, 15, 15> F1 =
-      -Eigen::Matrix<double, 15, 15>::Identity();  // holds for the biases
+    Eigen::Matrix<double, kNumResiduals, kNumResiduals> F1 =
+      -Eigen::Matrix<double, kNumResiduals, kNumResiduals>::Identity();  // holds for the biases
     F1.block<3, 3>(0, 0) = -C_S0_W;
     F1.block<3, 3>(3, 3) = -(okvis::kinematics::plus(Dq) * okvis::kinematics::oplus(T_WS_0.q()) *
                              okvis::kinematics::plus(T_WS_1.q().inverse()))
@@ -970,15 +975,16 @@ bool ImuError::EvaluateWithSigmaGradientAndHessian(const double * const *paramet
   Eigen::Map<Eigen::Matrix<double, 4, 1>> gradientVec(gradient);
   Eigen::Map<Eigen::Matrix<double, 4, 4>> hessianMat(hessian);
   for (size_t j = 0; j < 4; ++j) {
-    Eigen::Matrix<double, 15, 1> inf_e = information_ * error;
-    //Eigen::Matrix<double, 15, 15> Z = information_*dPdsigma_.at(j)*information_;
-    Eigen::Matrix<double, 15, 15> Y = information_ * dPdsigma_.at(j);
+    Eigen::Matrix<double, kNumResiduals, 1> inf_e = information_ * error;
+    //Eigen::Matrix<double, kNumResiduals, kNumResiduals> Z
+    //  = information_*dPdsigma_.at(j)*information_;
+    Eigen::Matrix<double, kNumResiduals, kNumResiduals> Y = information_ * dPdsigma_.at(j);
     gradientVec[int(j)] = 0.5 * (-inf_e.transpose() * dPdsigma_.at(j) * inf_e + Y.trace());
     // evaluate Hessian
     // diagonal first: dcost/dsigma_j^2
-    //Eigen::Matrix<double, 15, 15> Zdash
+    //Eigen::Matrix<double, kNumResiduals, kNumResiduals> Zdash
     // = -Z*dPdsigma_.at(j)*information_ - information_*dPdsigma_.at(j)*Z;
-    Eigen::Matrix<double, 15, 15> Ydash = -Y * information_ * dPdsigma_.at(j);
+    Eigen::Matrix<double, kNumResiduals, kNumResiduals> Ydash = -Y * information_ * dPdsigma_.at(j);
     hessianMat(int(j), int(j)) =
       0.5 * (2 * (inf_e.transpose() * dPdsigma_.at(j)) * information_ * (dPdsigma_.at(j) * inf_e) +
              Ydash.trace());
@@ -1063,12 +1069,12 @@ bool PseudoImuError::EvaluateWithMinimalJacobians(double const *const *parameter
   kinematics::Transformation T_WS_1_predicted(T_WS_0.r() + dr, T_WS_0.q());
 
   // compute the residual
-  Eigen::Matrix<double, 15, 1> error;
+  Eigen::Matrix<double, kNumResiduals, 1> error;
   error.head<3>() = C_S0_W * (T_WS_1_predicted.r() - T_WS_1.r());
   error.segment<3>(3) = 2.0 * ((T_WS_1.q().inverse() * T_WS_0.q()).coeffs().head<3>());
   error.segment<3>(6) = C_S0_W * (speedAndBiases_0.head<3>() - speedAndBiases_1.head<3>());
   error.segment<6>(9) = speedAndBiases_0.tail<6>() - speedAndBiases_1.tail<6>();
-  Eigen::Map<Eigen::Matrix<double, 15, 1>> weighted_error(residuals);
+  Eigen::Map<Eigen::Matrix<double, kNumResiduals, 1>> weighted_error(residuals);
   information_t squareRootInformation = information_t::Identity(); /// \todo
   squareRootInformation.block<3, 3>(0, 0) *= 1.0 / sqrt(Delta_t);
   squareRootInformation.block<3, 3>(3, 3) *= 1.0 / sqrt(Delta_t);
@@ -1081,7 +1087,7 @@ bool PseudoImuError::EvaluateWithMinimalJacobians(double const *const *parameter
   if (jacobians != nullptr) {
     if (jacobians[0] != nullptr) {
       // Jacobian w.r.t. minimal perturbance
-      Eigen::Matrix<double, 15, 6> Jp0 = Eigen::Matrix<double, 15, 6>::Zero();
+      Eigen::Matrix<double, kNumResiduals, 6> Jp0 = Eigen::Matrix<double, kNumResiduals, 6>::Zero();
       Jp0.block<3, 3>(0, 0) = C_S0_W;
       Jp0.block<3, 3>(0, 3) = C_S0_W * kinematics::crossMx(T_WS_1_predicted.r() - T_WS_1.r());
       Jp0.block<3, 3>(3, 3)
@@ -1089,28 +1095,29 @@ bool PseudoImuError::EvaluateWithMinimalJacobians(double const *const *parameter
       Jp0.block<3, 3>(6, 3) = C_S0_W
                               * kinematics::crossMx(speedAndBiases_0.head<3>()
                                                     - speedAndBiases_1.head<3>());
-      Eigen::Matrix<double, 15, 6> J0_minimal = squareRootInformation * Jp0;
+      Eigen::Matrix<double, kNumResiduals, 6> J0_minimal = squareRootInformation * Jp0;
 
       // pseudo inverse of the local parametrization Jacobian:
       Eigen::Matrix<double, 6, 7, Eigen::RowMajor> J_lift;
       PoseManifold::minusJacobian(parameters[0], J_lift.data());
 
       // hallucinate Jacobian w.r.t. state
-      Eigen::Map<Eigen::Matrix<double, 15, 7, Eigen::RowMajor>> J0(jacobians[0]);
+      Eigen::Map<Eigen::Matrix<double, kNumResiduals, 7, Eigen::RowMajor>> J0(jacobians[0]);
       J0 = J0_minimal * J_lift;
 
       // if requested, provide minimal Jacobians
       if (jacobiansMinimal != nullptr) {
         if (jacobiansMinimal[0] != nullptr) {
-          Eigen::Map<Eigen::Matrix<double, 15, 6, Eigen::RowMajor>> J0_minimal_mapped(
+          Eigen::Map<Eigen::Matrix<double, kNumResiduals, 6, Eigen::RowMajor>> J0_minimal_mapped(
             jacobiansMinimal[0]);
           J0_minimal_mapped = J0_minimal;
         }
       }
     }
     if (jacobians[1] != nullptr) {
-      Eigen::Map<Eigen::Matrix<double, 15, 9, Eigen::RowMajor>> J1(jacobians[1]);
-      Eigen::Matrix<double, 15, 9> Jsb0 = Eigen::Matrix<double, 15, 9>::Zero();
+      Eigen::Map<Eigen::Matrix<double, kNumResiduals, 9, Eigen::RowMajor>> J1(jacobians[1]);
+      Eigen::Matrix<double, kNumResiduals, 9> Jsb0 =
+        Eigen::Matrix<double, kNumResiduals, 9>::Zero();
       Jsb0.block<3, 3>(0, 0) = Delta_t * C_S0_W;
       Jsb0.block<3, 3>(6, 0) = C_S0_W;
       Jsb0.bottomRightCorner<6, 6>() = Eigen::Matrix<double, 6, 6>::Identity();
@@ -1119,7 +1126,7 @@ bool PseudoImuError::EvaluateWithMinimalJacobians(double const *const *parameter
       // if requested, provide minimal Jacobians
       if (jacobiansMinimal != nullptr) {
         if (jacobiansMinimal[1] != nullptr) {
-          Eigen::Map<Eigen::Matrix<double, 15, 9, Eigen::RowMajor>> J1_minimal_mapped(
+          Eigen::Map<Eigen::Matrix<double, kNumResiduals, 9, Eigen::RowMajor>> J1_minimal_mapped(
             jacobiansMinimal[1]);
           J1_minimal_mapped = J1;
         }
@@ -1127,41 +1134,42 @@ bool PseudoImuError::EvaluateWithMinimalJacobians(double const *const *parameter
     }
     if (jacobians[2] != nullptr) {
       // Jacobian w.r.t. minimal perturbance
-      Eigen::Matrix<double, 15, 6> Jp1 = Eigen::Matrix<double, 15, 6>::Zero();
+      Eigen::Matrix<double, kNumResiduals, 6> Jp1 = Eigen::Matrix<double, kNumResiduals, 6>::Zero();
       Jp1.block<3, 3>(0, 0) = -C_S0_W;
       Jp1.block<3, 3>(3, 3)
         = -kinematics::plus(T_WS_1.q().inverse() * T_WS_0.q()).topLeftCorner<3, 3>() * C_S0_W;
-      Eigen::Matrix<double, 15, 6> J2_minimal = squareRootInformation * Jp1;
+      Eigen::Matrix<double, kNumResiduals, 6> J2_minimal = squareRootInformation * Jp1;
 
       // pseudo inverse of the local parametrization Jacobian:
       Eigen::Matrix<double, 6, 7, Eigen::RowMajor> J_lift;
       PoseManifold::minusJacobian(parameters[2], J_lift.data());
 
       // hallucinate Jacobian w.r.t. state
-      Eigen::Map<Eigen::Matrix<double, 15, 7, Eigen::RowMajor> > J2(
+      Eigen::Map<Eigen::Matrix<double, kNumResiduals, 7, Eigen::RowMajor> > J2(
         jacobians[2]);
       J2 = J2_minimal * J_lift;
 
       // if requested, provide minimal Jacobians
       if (jacobiansMinimal != nullptr) {
         if (jacobiansMinimal[2] != nullptr) {
-          Eigen::Map<Eigen::Matrix<double, 15, 6, Eigen::RowMajor> > J2_minimal_mapped(
+          Eigen::Map<Eigen::Matrix<double, kNumResiduals, 6, Eigen::RowMajor> > J2_minimal_mapped(
             jacobiansMinimal[2]);
           J2_minimal_mapped = J2_minimal;
         }
       }
     }
     if (jacobians[3] != nullptr) {
-      Eigen::Matrix<double, 15, 9> Jsb1 = Eigen::Matrix<double, 15, 9>::Zero();
+      Eigen::Matrix<double, kNumResiduals, 9> Jsb1 =
+        Eigen::Matrix<double, kNumResiduals, 9>::Zero();
       Jsb1.block<3, 3>(6, 0) = -C_S0_W;
       Jsb1.bottomRightCorner<6, 6>() = -Eigen::Matrix<double, 6, 6>::Identity();
-      Eigen::Map<Eigen::Matrix<double, 15, 9, Eigen::RowMajor> > J3(jacobians[3]);
+      Eigen::Map<Eigen::Matrix<double, kNumResiduals, 9, Eigen::RowMajor> > J3(jacobians[3]);
       J3 = squareRootInformation * Jsb1;
 
       // if requested, provide minimal Jacobians
       if (jacobiansMinimal != nullptr) {
         if (jacobiansMinimal[3] != nullptr) {
-          Eigen::Map<Eigen::Matrix<double, 15, 9, Eigen::RowMajor> > J3_minimal_mapped(
+          Eigen::Map<Eigen::Matrix<double, kNumResiduals, 9, Eigen::RowMajor> > J3_minimal_mapped(
             jacobiansMinimal[3]);
           J3_minimal_mapped = J3;
         }

--- a/okvis_ceres/src/ImuError.cpp
+++ b/okvis_ceres/src/ImuError.cpp
@@ -48,9 +48,24 @@
 #include <okvis/kinematics/Transformation.hpp>
 #include <okvis/PseudoInverse.hpp>
 
+
 /// \brief okvis Main namespace of this package.
 namespace okvis {
 /// \brief ceres Namespace for ceres-related functionality implemented in okvis.
+
+namespace {
+/// \brief Linearly interpolate the gyroscope and accelerometer readings of a and b to target.
+/// \warning target is expected to lie within [a.timeStamp, b.timeStamp].
+ImuSensorReadings interpolate(
+  const ImuMeasurement & a, const ImuMeasurement & b, const Time & target)
+{
+  const double r = (target - a.timeStamp).toSec() / (b.timeStamp - a.timeStamp).toSec();
+  return ImuSensorReadings(
+    (1.0 - r) * a.measurement.gyroscopes + r * b.measurement.gyroscopes,
+    (1.0 - r) * a.measurement.accelerometers + r * b.measurement.accelerometers);
+}
+}  // namespace
+
 namespace ceres {
 
 std::atomic_bool ImuError::redoPropagationAlways(false);
@@ -170,70 +185,96 @@ ImuError::HelperMeasurements ImuError::computeNextHelperMeasurements(
   return next_helpers;
 }
 
-int ImuError::doPropagation(
-  PreintegratedMeasurements & preintegrated, HelperMeasurements & helpers,
-  Eigen::Matrix<double, kNumResiduals, kNumResiduals> & covariance,
-  const ImuParameters & imuParameters, const ImuMeasurementDeque & imuMeasurements,
+std::vector<ImuError::AlignedInterval> ImuError::alignAndCorrectMeasurements(
+  const ImuMeasurementDeque & imuMeasurements, const ImuParameters & imuParameters,
   const SpeedAndBias & speedAndBiases, const Time & t0, const Time & t1)
 {
-  Time time = t0;
-  const Time & end = t1;
+  std::vector<AlignedInterval> aligned;
+  
+  if (imuMeasurements.size() < 2) {
+    return aligned;  // no interval to integrate over
+  }
 
-  bool hasStarted = false;
-  int cnt = 0;
+  aligned.reserve(imuMeasurements.size());
+
   for (ImuMeasurementDeque::const_iterator it = imuMeasurements.begin();
        it != imuMeasurements.end() - 1; ++it) {
-    auto imu_0 = it->measurement;
-    auto imu_1 = (it + 1)->measurement;
+    ImuMeasurement m_0 = *it;
+    ImuMeasurement m_1 = *(it + 1);
 
-    Time current_time = it->timeStamp;
-    Time next_time = (it + 1)->timeStamp;
-    double dt = (next_time - time).toSec();
+    if (m_1.timeStamp < t0) {
+      continue;  // entirely before the preintegration period
+    }
 
+    if (t1 < m_0.timeStamp) {
+      break;  // entirely after it
+    }
+
+    // clip the interval to [t0, t1]
+    if (m_0.timeStamp < t0) {
+      m_0.measurement = interpolate(m_0, m_1, t0);
+      m_0.timeStamp = t0;
+    }
+
+    if (t1 < m_1.timeStamp) {
+      m_1.measurement = interpolate(m_0, m_1, t1);
+      m_1.timeStamp = t1;
+    }
+
+    const double dt = (m_1.timeStamp - m_0.timeStamp).toSec();
     if (dt <= 0.0) {
       continue;
     }
 
-    if (end < next_time) {
-      double interval = (next_time - it->timeStamp).toSec();
-      next_time = end;
-      dt = (next_time - time).toSec();
-      const double r = dt / interval;
-      imu_1.gyroscopes = ((1.0 - r) * imu_0.gyroscopes + r * imu_1.gyroscopes).eval();
-      imu_1.accelerometers = ((1.0 - r) * imu_0.accelerometers + r * imu_1.accelerometers).eval();
-    }
+    const ImuSensorReadings & imu_0 = m_0.measurement;
+    const ImuSensorReadings & imu_1 = m_1.measurement;
 
-    if (!hasStarted) {
-      hasStarted = true;
-      if (current_time < time) {
-        const double r = dt / (next_time - it->timeStamp).toSec();
-        imu_0.gyroscopes = (r * imu_0.gyroscopes + (1.0 - r) * imu_1.gyroscopes).eval();
-        imu_0.accelerometers = (r * imu_0.accelerometers + (1.0 - r) * imu_1.accelerometers).eval();
-      }
-    }
-
-    double sigma_g_c = imuParameters.sigma_g_c;
-    double sigma_a_c = imuParameters.sigma_a_c;
-    const double & sigma_gw_c = imuParameters.sigma_gw_c;
-    const double & sigma_aw_c = imuParameters.sigma_aw_c;
+    AlignedInterval interval;
+    interval.dt = dt;
+    interval.sigma_g_c = imuParameters.sigma_g_c;
+    interval.sigma_a_c = imuParameters.sigma_a_c;
 
     if (
       imu_0.gyroscopes.cwiseAbs().maxCoeff() > imuParameters.g_max ||
       imu_1.gyroscopes.cwiseAbs().maxCoeff() > imuParameters.g_max) {
-      sigma_g_c *= 100;
+      interval.sigma_g_c *= 100;
       LOG(WARNING) << "Gyr saturation - scaling sigma";
     }
 
     if (
       imu_0.accelerometers.cwiseAbs().maxCoeff() > imuParameters.a_max ||
       imu_1.accelerometers.cwiseAbs().maxCoeff() > imuParameters.a_max) {
-      sigma_a_c *= 100;
+      interval.sigma_a_c *= 100;
       LOG(WARNING) << "Acc saturation - scaling sigma";
     }
 
-    ImuSensorReadings imu{
+    interval.imu = ImuSensorReadings{
       0.5 * (imu_0.gyroscopes + imu_1.gyroscopes) - speedAndBiases.segment<3>(3),
       0.5 * (imu_0.accelerometers + imu_1.accelerometers) - speedAndBiases.segment<3>(6)};
+
+    aligned.push_back(interval);
+
+    if (m_1.timeStamp == t1) {
+      break;
+    }
+  }
+
+  return aligned;
+}
+
+int ImuError::doPropagation(
+  PreintegratedMeasurements & preintegrated, HelperMeasurements & helpers,
+  Eigen::Matrix<double, kNumResiduals, kNumResiduals> & covariance,
+  const ImuParameters & imuParameters, const std::vector<AlignedInterval> & intervals)
+{
+  const double & sigma_gw_c = imuParameters.sigma_gw_c;
+  const double & sigma_aw_c = imuParameters.sigma_aw_c;
+
+  for (const AlignedInterval & aligned : intervals) {
+    const double dt = aligned.dt;
+    const double & sigma_g_c = aligned.sigma_g_c;
+    const double & sigma_a_c = aligned.sigma_a_c;
+    const ImuSensorReadings & imu = aligned.imu;
 
     const auto & w = imu.gyroscopes;
     const auto & a = imu.accelerometers;
@@ -276,22 +317,14 @@ int ImuError::doPropagation(
     // memory shift
     preintegrated = next_preintegrated;
     helpers = next_helpers;
-    time = next_time;
-
-    ++cnt;
-
-    if (next_time == end) {
-      break;
-    }
   }
 
   covariance = 0.5 * (covariance + covariance.transpose().eval());
 
-  return cnt;
+  return int(intervals.size());
 }
 
 int ImuError::append(
-  const okvis::kinematics::Transformation & /*T_WS*/, const okvis::SpeedAndBias & speedAndBiases,
   const okvis::ImuMeasurementDeque & imuMeasurements, const okvis::Time & t_1)
 {
   OKVIS_ASSERT_TRUE_DBG(
@@ -320,8 +353,11 @@ int ImuError::append(
 
   setT1(t_1);
 
-  const int cnt = doPropagation(
-    preintegrated_, helpers_, P_delta_, imuParameters_, imuMeasurements, speedAndBiases, time, end);
+  // Keep the existing reference (linearisation) point when appending.
+  const std::vector<AlignedInterval> intervals =
+    alignAndCorrectMeasurements(imuMeasurements, imuParameters_, speedAndBiases_ref_, time, end);
+
+  const int cnt = doPropagation(preintegrated_, helpers_, P_delta_, imuParameters_, intervals);
 
   PseudoInverse::symmSqrtU(P_delta_, squareRootInformation_);
   information_ = squareRootInformation_.transpose() * squareRootInformation_;
@@ -353,9 +389,10 @@ int ImuError::redoPreintegration(
 
   reset();
 
-  const int cnt = doPropagation(
-    preintegrated_, helpers_, P_delta_, imuParameters_, imuMeasurements_, speedAndBiases, time,
-    end);
+  const std::vector<AlignedInterval> intervals =
+    alignAndCorrectMeasurements(imuMeasurements_, imuParameters_, speedAndBiases, time, end);
+
+  const int cnt = doPropagation(preintegrated_, helpers_, P_delta_, imuParameters_, intervals);
 
   PseudoInverse::symmSqrtU(P_delta_, squareRootInformation_);
   information_ = squareRootInformation_.transpose() * squareRootInformation_;
@@ -376,7 +413,6 @@ void ImuError::syncFrom(const ImuError & other)
   helpers_ = other.helpers_;
   P_delta_ = other.P_delta_;
   speedAndBiases_ref_ = other.speedAndBiases_ref_;
-  redo_ = other.redo_;
   redoCounter_ = other.redoCounter_;
   information_ = other.information_;
   squareRootInformation_ = other.squareRootInformation_;
@@ -394,7 +430,6 @@ std::shared_ptr<ImuErrorBase> ImuError::clone() const
   clone->helpers_ = helpers_;
   clone->P_delta_ = P_delta_;
   clone->speedAndBiases_ref_ = speedAndBiases_ref_;
-  clone->redo_ = redo_;
   clone->redoCounter_ = redoCounter_;
   clone->information_ = information_;
   clone->squareRootInformation_ = squareRootInformation_;
@@ -445,74 +480,22 @@ int ImuError::propagation(const okvis::ImuMeasurementDeque & imuMeasurements,
   Eigen::Matrix<double, kNumResiduals, kNumResiduals> P_delta =
     Eigen::Matrix<double, kNumResiduals, kNumResiduals>::Zero();
 
+  const std::vector<AlignedInterval> intervals =
+    alignAndCorrectMeasurements(imuMeasurements, imuParams, speedAndBiases, time, end);
+
   double Delta_t = 0;
-  bool hasStarted = false;
-  int i = 0;
-  for (okvis::ImuMeasurementDeque::const_iterator it = imuMeasurements.begin();
-        it != imuMeasurements.end(); ++it) {
+  for (const AlignedInterval & aligned : intervals) {
 
-    Eigen::Vector3d omega_S_0 = it->measurement.gyroscopes;
-    Eigen::Vector3d acc_S_0 = it->measurement.accelerometers;
-    Eigen::Vector3d omega_S_1 = (it + 1)->measurement.gyroscopes;
-    Eigen::Vector3d acc_S_1 = (it + 1)->measurement.accelerometers;
+    const double dt = aligned.dt;
+    const double & sigma_g_c = aligned.sigma_g_c;
+    const double & sigma_a_c = aligned.sigma_a_c;
 
-    // time delta
-    okvis::Time nexttime;
-    if ((it + 1) == imuMeasurements.end()) {
-      nexttime = t_end;
-    } else
-      nexttime = (it + 1)->timeStamp;
-    double dt = (nexttime - time).toSec();
-
-
-    if (end < nexttime) {
-      double interval = (nexttime - it->timeStamp).toSec();
-      nexttime = t_end;
-      dt = (nexttime - time).toSec();
-      const double r = dt / interval;
-      omega_S_1 = ((1.0 - r) * omega_S_0 + r * omega_S_1).eval();
-      acc_S_1 = ((1.0 - r) * acc_S_0 + r * acc_S_1).eval();
-    }
-
-    if (dt <= 0.0) {
-      continue;
-    }
     Delta_t += dt;
-
-    if (!hasStarted) {
-      hasStarted = true;
-      const double r = dt / (nexttime - it->timeStamp).toSec();
-      omega_S_0 = (r * omega_S_0 + (1.0 - r) * omega_S_1).eval();
-      acc_S_0 = (r * acc_S_0 + (1.0 - r) * acc_S_1).eval();
-    }
-
-    // ensure integrity
-    double sigma_g_c = imuParams.sigma_g_c;
-    double sigma_a_c = imuParams.sigma_a_c;
-
-    if (fabs(omega_S_0[0]) > imuParams.g_max
-        || fabs(omega_S_0[1]) > imuParams.g_max
-        || fabs(omega_S_0[2]) > imuParams.g_max
-        || fabs(omega_S_1[0]) > imuParams.g_max
-        || fabs(omega_S_1[1]) > imuParams.g_max
-        || fabs(omega_S_1[2]) > imuParams.g_max) {
-      sigma_g_c *= 100;
-      LOG(WARNING) << "gyr saturation";
-    }
-
-    if (fabs(acc_S_0[0]) > imuParams.a_max || fabs(acc_S_0[1]) > imuParams.a_max
-        || fabs(acc_S_0[2]) > imuParams.a_max
-        || fabs(acc_S_1[0]) > imuParams.a_max
-        || fabs(acc_S_1[1]) > imuParams.a_max
-        || fabs(acc_S_1[2]) > imuParams.a_max) {
-      sigma_a_c *= 100;
-      LOG(WARNING) << "acc saturation";
-    }
 
     // actual propagation
     // orientation:
     Eigen::Quaterniond dq;
-    const Eigen::Vector3d omega_S_true = (0.5*(omega_S_0+omega_S_1) - speedAndBiases.segment<3>(3));
+    const Eigen::Vector3d omega_S_true = aligned.imu.gyroscopes;
     const double theta_half = omega_S_true.norm() * 0.5 * dt;
     const double sinc_theta_half = ode::sinc(theta_half);
     const double cos_theta_half = cos(theta_half);
@@ -522,7 +505,7 @@ int ImuError::propagation(const okvis::ImuMeasurementDeque & imuMeasurements,
     // rotation matrix integral:
     const Eigen::Matrix3d C = Delta_q.toRotationMatrix();
     const Eigen::Matrix3d C_1 = Delta_q_1.toRotationMatrix();
-    const Eigen::Vector3d acc_S_true = (0.5*(acc_S_0+acc_S_1) - speedAndBiases.segment<3>(6));
+    const Eigen::Vector3d acc_S_true = aligned.imu.accelerometers;
     const Eigen::Matrix3d C_integral_1 = C_integral + 0.5*(C + C_1)*dt;
     const Eigen::Vector3d acc_integral_1 = acc_integral + 0.5*(C + C_1)*acc_S_true*dt;
     // rotation matrix double integral:
@@ -584,13 +567,6 @@ int ImuError::propagation(const okvis::ImuMeasurementDeque & imuMeasurements,
     acc_integral = acc_integral_1;
     cross = cross_1;
     dv_db_g = dv_db_g_1;
-    time = nexttime;
-
-    ++i;
-
-    if (nexttime == t_end)
-      break;
-
   }
 
   // actual propagation output:
@@ -627,7 +603,7 @@ int ImuError::propagation(const okvis::ImuMeasurementDeque & imuMeasurements,
     T.block<3,3>(6,6) = C_WS_0;
     P = T * P_delta * T.transpose();
   }
-  return i;
+  return int(intervals.size());
 }
 
 bool ImuError::initPose(const ImuMeasurementDeque &imuMeasurements,
@@ -705,8 +681,8 @@ bool ImuError::EvaluateWithMinimalJacobians(double const* const * parameters,
     std::lock_guard<std::mutex> lock(preintegrationMutex_);
     Delta_b = speedAndBiases_0.tail<6>()
           - speedAndBiases_ref_.tail<6>();
-    redo_ = redo_ || (Delta_b.head<3>().norm() > 0.0003);
-    if ((redo_ && ((imuMeasurements_.size() < 50) || redoPropagationAlways)) || redoCounter_==0) {
+    const bool redo = Delta_b.head<3>().norm() > 0.0003;
+    if (redo || redoPropagationAlways || redoCounter_ == 0) {
       const int steps = redoPreintegration(T_WS_0, speedAndBiases_0);
       if(steps<=0) {
         for(const auto & m : imuMeasurements_)
@@ -726,7 +702,6 @@ bool ImuError::EvaluateWithMinimalJacobians(double const* const * parameters,
 
       redoCounter_++;
       Delta_b.setZero();
-      redo_ = false;
     }
   }
 

--- a/okvis_ceres/src/ViGraphEstimator.cpp
+++ b/okvis_ceres/src/ViGraphEstimator.cpp
@@ -83,16 +83,10 @@ bool ViGraphEstimator::eliminateStateByImuMerge(StateId stateId, StateId refId)
   // the IMU link to append
   ImuLink & previousImuLink = previousState.nextImuLink;
 
-  // obtain current estimates
-  kinematics::Transformation T_WS = state.pose->estimate();
-  SpeedAndBias speedAndBias = state.speedAndBias->estimate();
-
   if(imuParametersVec_.at(0).use) {
     // append
     std::static_pointer_cast<ceres::ImuError>(previousImuLink.errorTerm)
-      ->append(T_WS,
-               speedAndBias,
-               std::static_pointer_cast<ceres::ImuError>(state.nextImuLink.errorTerm)
+      ->append(std::static_pointer_cast<ceres::ImuError>(state.nextImuLink.errorTerm)
                  ->imuMeasurements(),
                state.nextImuLink.errorTerm->t1());
   } else {


### PR DESCRIPTION
## IMU preintegration: reference point, redo gate, interval alignment

Three fixes to `ImuError`, on top of the preceding struct refactor.

**Wrong linearisation point in `append()`.** The appended segment was integrated against the speed/bias estimate at append time, while the existing  preintegration was built against `speedAndBiases_ref_`.

**Redo gate never fired on long terms.** The condition was `redo_ && (imuMeasurements_.size() < 50 || redoPropagationAlways)`, so a term  holding ≥50 measurements never re-preintegrated however far the gyro bias drifted, and `redoPropagationAlways` was dead whenever `redo_` was false. 

**Alignment extracted.** Measurement alignment and bias correction were duplicated between `propagation()` and `doPropagation()` and had drifted apart  in three places. Both now share `alignAndCorrectMeasurements()`, which returns  one entry per integration interval. `doPropagation()` consumes intervals rather  than raw measurements. This fixes a sub-sample interpolation bug in both old copies: when t0 and  t1 fell inside a single IMU sample interval, `dt` was measured from t0 but the interval length from the raw sample timestamp, mis-interpolating both endpoints.